### PR TITLE
feat: make use of resolvables from structs and deprecate own

### DIFF
--- a/lib/rest.ex
+++ b/lib/rest.ex
@@ -29,7 +29,20 @@ defmodule Crux.Rest do
   """
 
   alias Crux.Rest.{ApiError, Handler, Request, Util, Version}
-  alias Crux.Structs.{Channel, Emoji, Guild, Message, Overwrite, Role, Snowflake, User}
+
+  alias Crux.Structs.{
+    AuditLog,
+    Channel,
+    Emoji,
+    Guild,
+    Invite,
+    Message,
+    Overwrite,
+    Role,
+    Snowflake,
+    User,
+    Webhook
+  }
 
   require Version
 

--- a/lib/rest.ex
+++ b/lib/rest.ex
@@ -29,6 +29,7 @@ defmodule Crux.Rest do
   """
 
   alias Crux.Rest.{ApiError, Handler, Request, Util, Version}
+  alias Crux.Structs.{Channel, Emoji, Guild, Message, Overwrite, Role, Snowflake, User}
 
   require Version
 
@@ -42,6 +43,8 @@ defmodule Crux.Rest do
     Received as integers via the gateway, but as strings via http.
 
   > They are normalized to integers via `Crux.Structs`.
+
+  > Deprecated: Use `Crux.Snowflake.resolvable()` instead
   """
   Version.typesince("0.1.0")
   @type snowflake :: non_neg_integer()
@@ -118,12 +121,12 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_message(
-              channel :: Util.channel_id_resolvable(),
+              channel :: Channel.id_resolvable(),
               args :: Crux.Rest.create_message_data()
             ) :: {:ok, Message.t()} | {:error, term()}
 
   @typedoc """
-    Used to edit messages via `c:edit_message/2` or `edit_message/3`.
+    Used to edit messages via `c:edit_message/2` or `c:edit_message/3`.
 
     The content my not exceed 2000 chars, this limit is enfored on discord's end.
   """
@@ -157,8 +160,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback edit_message(
-              channel_id :: Util.channel_id_resolvable(),
-              message_id :: Util.message_id_resolvable(),
+              channel_id :: Channel.id_resolvable(),
+              message_id :: Message.id_resolvable(),
               args :: Crux.Rest.message_edit_data()
             ) :: {:ok, Message.t()} | {:error, term()}
 
@@ -179,8 +182,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_message(
-              channel_id :: Util.channel_id_resolvable(),
-              message_id :: Util.message_id_resolvable()
+              channel_id :: Channel.id_resolvable(),
+              message_id :: Message.id_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -191,8 +194,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_messages(
-              channel :: Util.channel_id_resolvable(),
-              messages :: [Util.message_id_resolvable()]
+              channel :: Channel.id_resolvable(),
+              messages :: [Message.id_resolvable()]
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -203,8 +206,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_message(
-              channel :: Util.channel_id_resolvable(),
-              message_id :: Util.message_id_resolvable()
+              channel :: Channel.id_resolvable(),
+              message_id :: Message.id_resolvable()
             ) :: {:ok, Message} | {:error, term()}
 
   @typedoc """
@@ -219,15 +222,15 @@ defmodule Crux.Rest do
 
   @type get_messages_data ::
           %{
-            optional(:around) => Crux.Rest.snowflake(),
-            optional(:before) => Crux.Rest.snowflake(),
-            optional(:after) => Crux.Rest.snowflake(),
+            optional(:around) => Message.id_resolvable(),
+            optional(:before) => Message.id_resolvable(),
+            optional(:after) => Message.id_resolvable(),
             optional(:limit) => pos_integer()
           }
           | [
-              {:around, Crux.Rest.snowflake()}
-              | {:before, Crux.Rest.snowflake()}
-              | {:after, Crux.Rest.snowflake()}
+              {:around, Message.id_resolvable()}
+              | {:before, Message.id_resolvable()}
+              | {:after, Message.id_resolvable()}
               | {:limit, pos_integer()}
             ]
 
@@ -239,9 +242,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_messages(
-              channel :: Util.channel_id_resolvable(),
+              channel :: Channel.id_resolvable(),
               args :: Crux.Rest.get_messages_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => Message.t()}} | {:error, term()}
+            ) :: {:ok, %{required(Snowflake.t()) => Message.t()}} | {:error, term()}
 
   ### End Message
 
@@ -255,8 +258,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_reaction(
-              message :: Util.message_id_resolvable(),
-              emoji :: Util.emoji_identifier_resolvable()
+              message :: Message.id_resolvable(),
+              emoji :: Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -267,9 +270,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_reaction(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable(),
-              emoji :: Util.emoji_id_resolvable()
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable(),
+              emoji :: Emoji.id_resolvable()
             ) :: :ok | {:error, term()}
 
   @typedoc """
@@ -283,13 +286,13 @@ defmodule Crux.Rest do
 
   @type get_reactions_data ::
           %{
-            optional(:before) => Crux.Rest.snowflake(),
-            optional(:after) => Crux.Rest.snowflake(),
+            optional(:before) => User.id_resolvable(),
+            optional(:after) => User.id_resolvable(),
             optional(:limit) => pos_integer()
           }
           | [
-              {:before, Crux.Rest.snowflake()}
-              | {:after, Crux.Rest.snowflake()}
+              {:before, User.id_resolvable()}
+              | {:after, Snowflake.id_resolvable()}
               | {:limit, pos_integer()}
             ]
 
@@ -303,19 +306,19 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_reactions(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable(),
-              emoji :: Util.emoji_identifier_resolvable(),
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable(),
+              emoji :: Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => User.t()}} | {:error, term()}
+            ) :: {:ok, %{required(Snowflake.t()) => User.t()}} | {:error, term()}
 
   Version.since("0.2.0")
 
   @callback get_reactions(
               message :: Message.t(),
-              emoji :: Util.emoji_identifier_resolvable(),
+              emoji :: Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => User.t()}} | {:error, term()}
+            ) :: {:ok, %{required(Snowflake.t()) => User.t()}} | {:error, term()}
 
   @doc """
     Deletes a user from a reaction.
@@ -327,10 +330,10 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_reaction(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable(),
-              emoji :: Util.emoji_identifier_resolvable(),
-              user :: Util.user_id_resolvable()
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable(),
+              emoji :: Emoji.identifier_resolvable(),
+              user :: User.id_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -342,7 +345,7 @@ defmodule Crux.Rest do
 
   @callback delete_all_reactions(
               message :: Message.t(),
-              emoji :: Util.emoji_identifier_resolvable()
+              emoji :: Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -353,9 +356,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_all_reactions(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable(),
-              emoji :: Util.emoji_identifier_resolvable()
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable(),
+              emoji :: Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
 
   ### End Reactions
@@ -371,7 +374,7 @@ defmodule Crux.Rest do
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/channel#trigger-typing-indicator).
   """
   Version.since("0.2.0")
-  @callback trigger_typing(channel :: Util.channel_id_resolvable()) :: :ok | {:error, term()}
+  @callback trigger_typing(channel :: Channel.id_resolvable()) :: :ok | {:error, term()}
 
   @doc """
     Adds a message to the pinned messages of a channel.
@@ -392,8 +395,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback add_pinned_message(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable()
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -413,8 +416,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_pinned_message(
-              channel :: Util.channel_id_resolvable(),
-              message :: Util.message_id_resolvable()
+              channel :: Channel.id_resolvable(),
+              message :: Message.id_resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -425,7 +428,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_channel(channel :: Util.resolve_channel_id()) ::
+  @callback get_channel(channel :: Channel.id_resolvable()) ::
               {:ok, Channel.t()} | {:error, term()}
 
   @typedoc """
@@ -448,7 +451,7 @@ defmodule Crux.Rest do
             optional(:icon) => Util.image(),
             optional(:name) => String.t() | nil,
             optional(:nsfw) => boolean(),
-            optional(:parent_id) => Crux.Rest.snowflake() | nil,
+            optional(:parent_id) => Channel.id_resolvable() | nil,
             optional(:permission_overwrites) => [Overwrite.t()],
             optional(:position) => non_neg_integer(),
             optional(:rate_limit_per_user) => non_neg_integer(),
@@ -461,7 +464,7 @@ defmodule Crux.Rest do
               | {:icon, Util.image()}
               | {:name, String.t() | nil}
               | {:nsfw, boolean()}
-              | {:parent_id, Crux.Rest.snowflake() | nil}
+              | {:parent_id, Channel.id_resolvable() | nil}
               | {:permission_overwrites, [Overwrite.t()]}
               | {:position, non_neg_integer()}
               | {:rate_limit_per_user, non_neg_integer()}
@@ -478,7 +481,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_channel(
-              channel :: Util.channel_id_resolvable(),
+              channel :: Channel.id_resolvable(),
               data :: Crux.Rest.modify_channel_data()
             ) :: {:ok, Channel.t()} | {:error, term()}
 
@@ -490,7 +493,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_channel(
-              channel :: Util.channel_id_resolvable(),
+              channel :: Channel.id_resolvable(),
               reason :: String.t()
             ) :: {:ok, Channel.t()} | {:error, term()}
 
@@ -523,8 +526,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback edit_channel_permissions(
-              channel :: Util.channel_id_resolvable(),
-              target :: Util.overwrite_target_resolvable(),
+              channel :: Channel.id_resolvable(),
+              target :: Overwrite.target_resolvable(),
               data :: Crux.Rest.edit_channel_permissions_data()
             ) :: :ok | {:error, :missing_target} | {:error, term()}
 
@@ -535,7 +538,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_channel_invites(channel :: Util.channel_id_resolvable()) ::
+  @callback get_channel_invites(channel :: Channel.id_resolvable()) ::
               {:ok, %{required(String.t()) => Invite.t()}} | {:error, term()}
 
   @typedoc """
@@ -575,7 +578,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_channel_invite(
-              channel :: Util.channel_id_resolvable(),
+              channel :: Channel.id_resolvable(),
               args :: Crux.Rest.create_channel_invite_data()
             ) :: {:ok, Invite.t()} | {:error, term()}
 
@@ -587,8 +590,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_channel_permissions(
-              channel :: Util.channel_id_resolvable(),
-              target :: Util.overwrite_target_resolvable(),
+              channel :: Channel.id_resolvable(),
+              target :: Overwrite.target_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -599,8 +602,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_pinned_messages(channel :: Util.channel_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Message.t()}} | {:error, term()}
+  @callback get_pinned_messages(channel :: Channel.id_resolvable()) ::
+              {:ok, %{required(Snowflake.t()) => Message.t()}} | {:error, term()}
 
   ### End Channel
 
@@ -614,8 +617,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback list_guild_emojis(guild :: Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Emoji.t()}} | {:error, term()}
+  @callback list_guild_emojis(guild :: Guild.id_resolvable()) ::
+              {:ok, %{required(Snowflake.t()) => Emoji.t()}} | {:error, term()}
 
   @doc """
     Gets an emoji from a guild
@@ -626,8 +629,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_guild_emoji(
-              guild :: Util.guild_id_resolvable(),
-              emoji :: Util.emoji_id_resolvable()
+              guild :: Guild.id_resolvable(),
+              emoji :: Emoji.id_resolvable()
             ) :: {:ok, Emoji} | {:error, term()}
 
   @typedoc """
@@ -645,13 +648,13 @@ defmodule Crux.Rest do
           %{
             required(:name) => String.t(),
             required(:image) => Util.image(),
-            optional(:roles) => [Role.t() | Crux.Rest.snowflake()],
+            optional(:roles) => [Role.id_resolvable()],
             optional(:reason) => String.t()
           }
           | [
               {:name, String.t()}
               | {:image, Util.image()}
-              | {:roles, [Role.t() | Crux.Rest.snowflake()]}
+              | {:roles, [Role.id_resolvable()]}
               | {:reason, String.t()}
             ]
 
@@ -663,7 +666,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_guild_emoji(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_emoji_data()
             ) :: {:ok, Emoji} | {:error, term}
 
@@ -677,12 +680,12 @@ defmodule Crux.Rest do
   @type modify_guild_emoji_data ::
           %{
             optional(:name) => String.t(),
-            optional(:roles) => [Role.t() | Crux.Rest.snowflake()],
+            optional(:roles) => [Role.id_resolvable()],
             optional(:reason) => String.t()
           }
           | [
               {:name, String.t()}
-              | {:roles, [Role.t() | Crux.Rest.snowflake()]}
+              | {:roles, [Role.id_resolvable()]}
               | {:reason, String.t()}
             ]
 
@@ -694,8 +697,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_emoji(
-              guild :: Util.guild_id_resolvable(),
-              emoji :: Util.emoji_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              emoji :: Emoji.id_resolvable(),
               data :: Crux.Rest.modify_guild_emoji_data()
             ) :: {:ok, Emoji} | {:error, term()}
 
@@ -707,8 +710,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_guild_emoji(
-              guild :: Util.guild_id_resolvable(),
-              emoji :: Util.emoji_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              emoji :: Emoji.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -726,11 +729,10 @@ defmodule Crux.Rest do
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/guild#get-guild)
   """
   Version.since("0.2.0")
-  @callback get_guild(guild :: Util.guild_id_resolvable()) :: {:ok, Guild.t()} | {:error, term()}
+  @callback get_guild(guild :: Guild.id_resolvable()) :: {:ok, Guild.t()} | {:error, term()}
 
-  # TODO: :that:
   @typedoc """
-    TBD, see `c:modify_guild/2`
+    Used to modify a guild using `c:modify_guild/2`.
   """
   Version.typesince("0.1.0")
 
@@ -741,13 +743,13 @@ defmodule Crux.Rest do
             optional(:verification_level) => non_neg_integer(),
             optional(:default_message_notifications) => non_neg_integer(),
             optional(:explicit_content_filter) => non_neg_integer(),
-            optional(:afk_channel_id) => Crux.Rest.snowflake() | nil,
+            optional(:afk_channel_id) => Channel.id_resolvable() | nil,
             optional(:afk_timeout) => non_neg_integer(),
             optional(:icon) => Util.image(),
             optional(:splash) => Util.image(),
             optional(:banner) => Util.image(),
-            optional(:owner_id) => Crux.Rest.snowflake(),
-            optional(:system_channel_id) => Crux.Rest.snowflake() | nil,
+            optional(:owner_id) => User.id_resolvable(),
+            optional(:system_channel_id) => Channel.id_resolvable() | nil,
             optional(:reason) => String.t()
           }
           | [
@@ -756,13 +758,13 @@ defmodule Crux.Rest do
               | {:verification_level, non_neg_integer()}
               | {:default_message_notifications, non_neg_integer()}
               | {:explicit_content_filter, non_neg_integer()}
-              | {:afk_channel_id, Crux.Rest.snowflake() | nil}
+              | {:afk_channel_id, Channel.id_resolvable() | nil}
               | {:afk_timeout, non_neg_integer()}
               | {:icon, Util.image()}
               | {:splash, Util.image()}
               | {:banner, Util.image()}
-              | {:owner_id, Crux.Rest.snowflake()}
-              | {:system_channel_id, Crux.Rest.snowflake() | nil}
+              | {:owner_id, User.id_resolvable()}
+              | {:system_channel_id, Channel.id_resolvable() | nil}
               | {:reason, String.t()}
             ]
 
@@ -774,17 +776,17 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data :: Crux.Rest.modify_guild_data()
             ) :: {:ok, Guild.t()} | {:error, term()}
 
   @doc """
-    Deletes a guild, can only be used if the executing user is the owner.
+    Deletes a guild, can only be used if the executing user is the owner of the guild.
 
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/guild#delete-guild).
   """
   Version.since("0.2.0")
-  @callback delete_guild(guild :: Util.guild_id_resolvable()) :: :ok | {:error, term()}
+  @callback delete_guild(guild :: Guild.id_resolvable()) :: :ok | {:error, term()}
 
   @typedoc """
     Used to filter audit log results via `c:get_audit_logs/2`.
@@ -794,15 +796,15 @@ defmodule Crux.Rest do
 
   @type audit_log_options ::
           %{
-            optional(:user_id) => Crux.Rest.snowflake(),
+            optional(:user_id) => User.id_resolvable(),
             optional(:action_type) => pos_integer(),
-            optional(:before) => Crux.Rest.snowflake(),
+            optional(:before) => User.id_resolvable(),
             optional(:limit) => pos_integer()
           }
           | [
-              {:user_id, Crux.Rest.snowflake()}
+              {:user_id, User.id_resolvable()}
               | {:action_type, pos_integer()}
-              | {:before, Crux.Rest.snowflake()}
+              | {:before, User.id_resolvable()}
               | {:limit, pos_integer}
             ]
 
@@ -812,7 +814,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_audit_logs(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               options :: Crux.Rest.audit_log_options() | nil
             ) :: {:ok, AuditLog.t()} | {:error, term()}
 
@@ -824,8 +826,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_channels(guild :: Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Channel.t()}} | {:error, term()}
+  @callback get_guild_channels(guild :: Guild.id_resolvable()) ::
+              {:ok, %{required(Snowflake.t()) => Channel.t()}} | {:error, term()}
 
   @typedoc """
     Used to create a channel via `c:create_guild_channel/2`.
@@ -844,13 +846,13 @@ defmodule Crux.Rest do
             optional(:permission_overwrites) => [
               Overwrite.t()
               | %{
-                  required(:id) => Crux.Rest.snowflake(),
+                  required(:id) => Role.id_resolvable() | Channel.id_resolvable(),
                   required(:type) => String.t(),
                   optional(:allow) => non_neg_integer(),
                   optional(:deny) => non_neg_integer()
                 }
             ],
-            optional(:parent_id) => Crux.Rest.snowflake() | nil,
+            optional(:parent_id) => Channel.id_resolvable() | nil,
             optional(:nsfw) => boolean(),
             optional(:reason) => String.t()
           }
@@ -863,13 +865,13 @@ defmodule Crux.Rest do
                  [
                    Overwrite.t()
                    | %{
-                       required(:id) => Crux.Rest.snowflake(),
+                       required(:id) => Role.id_resolvable() | Channel.id_resolvable(),
                        required(:type) => String.t(),
                        optional(:allow) => non_neg_integer(),
                        optional(:deny) => non_neg_integer()
                      }
                  ]}
-              | {:parent_id, Crux.Rest.snowflake() | nil}
+              | {:parent_id, Channel.id_resolvable() | nil}
               | {:nsfw, boolean()}
               | {:reason, String.t()}
             ]
@@ -882,20 +884,18 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_guild_channel(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_channel_data()
             ) :: {:ok, Channel.t()} | {:error, term()}
 
   @typedoc """
     Used to change a channel's position via `c:modify_guild_channel_positions/2`.
+
+  > Deprecated: Use `Crux.Structs.Channel.position_resolvable()` instead
   """
   Version.typesince("0.1.0")
 
-  @type modify_guild_channel_positions_data_entry ::
-          {Channel.t(), integer()}
-          | {Crux.Rest.snowflake(), integer()}
-          | %{required(:channel) => Channel.t(), required(:position) => integer()}
-          | %{required(:id) => Crux.Rest.snowflake(), required(:position) => integer()}
+  @type modify_guild_channel_positions_data_entry :: Channel.position_resolvable()
 
   @doc """
     Modifyies the position of a list of channels in a guild.
@@ -905,8 +905,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_channel_positions(
-              guild :: Util.guild_id_resolvable(),
-              channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
+              guild :: Guild.id_resolvable(),
+              channels :: [Channel.position_resolvable()]
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -919,21 +919,21 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_guild_member(
-              guild :: Util.guild_id_resolvable(),
-              user :: Util.user_id_resolvable()
+              guild :: Guild.id_resolvable(),
+              user :: User.id_resolvable()
             ) :: {:ok, Member.t()} | {:error, term()}
 
   @typedoc """
-    Used to list guild members via `c:listt_guild_members/2`.
+    Used to list guild members via `c:list_guild_members/2`.
   """
   Version.typesince("0.1.0")
 
   @type list_guild_members_options ::
           %{
             optional(:limit) => pos_integer(),
-            optional(:after) => Crux.Rest.snowflake()
+            optional(:after) => User.id_resolvable()
           }
-          | [{:limit, pos_integer()} | {:after, Crux.Rest.snowflake()}]
+          | [{:limit, pos_integer()} | {:after, User.id_resolvable()}]
 
   @doc """
     Gets a list of members from the guild.
@@ -943,9 +943,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback list_guild_members(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               options :: Crux.Rest.list_guild_members_options()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => Member.t()}} | {:error, term()}
+            ) :: {:ok, %{required(Snowflake.t()) => Member.t()}} | {:error, term()}
 
   @typedoc """
     Used to add a member to a guild via `c:add_guild_member/3`.
@@ -956,7 +956,7 @@ defmodule Crux.Rest do
           %{
             required(:access_token) => String.t(),
             optional(:nick) => String.t() | nil,
-            optional(:roles) => [Crux.Rest.snowflake()],
+            optional(:roles) => [Role.id_resolvable()],
             optional(:mute) => boolean(),
             optional(:deaf) => boolean(),
             optional(:reason) => String.t()
@@ -964,7 +964,7 @@ defmodule Crux.Rest do
           | [
               {:access_token, String.t()}
               | {:nick, String.t() | nil}
-              | {:roles, [Crux.Rest.snowflake()]}
+              | {:roles, [Role.id_resolvable()]}
               | {:mute, boolean()}
               | {:deaf, boolean()}
               | {:reason, String.t()}
@@ -978,8 +978,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback add_guild_member(
-              guild :: Util.guild_id_resolvable(),
-              user :: Util.user_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              user :: User.id_resolvable(),
               data :: Crux.Rest.add_guild_member_data()
             ) :: {:ok, Member.t()} | {:error, term()}
 
@@ -994,18 +994,18 @@ defmodule Crux.Rest do
   @type modify_guild_member_data ::
           %{
             optional(:nick) => String.t() | nil,
-            optional(:roles) => [Crux.Rest.snowflake()],
+            optional(:roles) => [Role.id_resolvable()],
             optional(:mute) => boolean(),
             optional(:deaf) => boolean(),
-            optional(:channel_id) => Crux.Rest.snowflake() | nil,
+            optional(:channel_id) => Channel.id_resolvable() | nil,
             optional(:reason) => String.t()
           }
           | [
               {:nick, String.t() | nil}
-              | {:roles, [Crux.Rest.snowflake()]}
+              | {:roles, [Role.id_resolvable()]}
               | {:mute, boolean()}
               | {:deaf, boolean()}
-              | {:channel_id, Crux.Rest.snowflake() | nil}
+              | {:channel_id, Channel.id_resolvable() | nil}
               | {:reason, String.t()}
             ]
 
@@ -1017,8 +1017,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_member(
-              guild :: Util.guild_id_resolvable(),
-              member :: Util.user_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              member :: User.id_resolvable(),
               data :: Crux.Rest.modify_guild_member_data()
             ) :: :ok | {:error, term()}
 
@@ -1033,7 +1033,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_current_users_nick(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               nick :: String.t(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
@@ -1046,9 +1046,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback add_guild_member_role(
-              guild :: Util.guild_id_resolvable(),
-              member :: Util.user_id_resolvable(),
-              role :: Util.role_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              member :: User.id_resolvable(),
+              role :: Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -1060,9 +1060,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback remove_guild_member_role(
-              guild :: Util.guild_id_resolvable(),
-              member :: Util.user_id_resolvable(),
-              role :: Util.role_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              member :: User.id_resolvable(),
+              role :: Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -1073,8 +1073,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_bans(guild :: Util.guild_id_resolvable()) ::
-              {:ok, %{Crux.Rest.snowflake() => %{user: User.t(), reason: String.t() | nil}}}
+  @callback get_guild_bans(guild :: Guild.id_resolvable()) ::
+              {:ok, %{Snowflake.t() => %{user: User.t(), reason: String.t() | nil}}}
               | {:error, term()}
 
   @doc """
@@ -1086,7 +1086,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_ban(guild :: Util.guild_id_resolvable(), user :: Util.user_id_resolvable()) ::
+  @callback get_guild_ban(guild :: Guild.id_resolvable(), user :: User.id_resolvable()) ::
               {:ok, %{user: User.t(), reason: String.t() | nil}} | {:error, term()}
 
   @doc """
@@ -1097,8 +1097,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_guild_ban(
-              guild :: Util.guild_id_resolvable(),
-              user :: Util.user_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              user :: User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -1110,8 +1110,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback remove_guild_ban(
-              guild :: Util.guild_id_resolvable(),
-              user :: Util.user_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              user :: User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -1123,8 +1123,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_roles(guild :: Util.guild_id_resolvable()) ::
-              {:ok, %{Crux.Rest.snowflake() => Role.t()}} | {:error, term()}
+  @callback get_guild_roles(guild :: Guild.id_resolvable()) ::
+              {:ok, %{Snowflake.t() => Role.t()}} | {:error, term()}
 
   @typedoc """
     Used to create a role in a guild with `c:create_guild_role/2`.
@@ -1157,7 +1157,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_guild_role(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
             ) :: {:ok, Role.t()} | {:error, term()}
 
@@ -1169,9 +1169,9 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_role_positions(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data :: Util.modify_guild_role_positions_data()
-            ) :: {:ok, %{Crux.Rest.snowflake() => Role.t()}} | {:error, term()}
+            ) :: {:ok, %{Snowflake.t() => Role.t()}} | {:error, term()}
 
   @doc """
     Modifies a role in a guild.
@@ -1181,8 +1181,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_role(
-              guild :: Util.guild_id_resolvable(),
-              role :: Util.role_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              role :: Role.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
             ) :: {:ok, Role.t()} | {:error, term()}
 
@@ -1194,8 +1194,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_guild_role(
-              guild :: Util.guild_id_resolvable(),
-              role :: Util.role_id_resolvable(),
+              guild :: Guild.id_resolvable(),
+              role :: Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
 
@@ -1206,7 +1206,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_prune_count(guild :: Util.guild_id_resolvable(), days :: pos_integer()) ::
+  @callback get_guild_prune_count(guild :: Guild.id_resolvable(), days :: pos_integer()) ::
               {:ok, non_neg_integer()} | {:error, term()}
 
   @typedoc """
@@ -1229,7 +1229,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback begin_guild_prune(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               opts :: Crux.Rest.begin_guild_prune_opts()
             ) :: {:ok, non_neg_integer()} | {:error, term()}
 
@@ -1242,7 +1242,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_voice_regions(guild :: Util.guild_id_resolvable()) ::
+  @callback get_guild_voice_regions(guild :: Guild.id_resolvable()) ::
               {:ok, term()} | {:error, term()}
 
   @doc """
@@ -1252,7 +1252,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_invites(guild :: Util.guild_id_resolvable()) ::
+  @callback get_guild_invites(guild :: Guild.id_resolvable()) ::
               {:ok, %{String.t() => Invite.t()}} | {:error, term()}
 
   @doc """
@@ -1264,7 +1264,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_integrations(guild :: Util.guild_id_resolvable()) ::
+  @callback get_guild_integrations(guild :: Guild.id_resolvable()) ::
               {:ok, list()} | {:error, term()}
 
   @doc """
@@ -1275,10 +1275,10 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback create_guild_integration(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data ::
-                %{type: String.t(), id: Crux.Rest.snowflake()}
-                | [{:type, String.t()} | {:id, Crux.Rest.snowflake()}]
+                %{type: String.t(), id: Snowflake.resolvable()}
+                | [{:type, String.t()} | {:id, Snowflake.resolvable()}]
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -1289,8 +1289,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback modify_guild_integration(
-              guild :: Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake(),
+              guild :: Guild.id_resolvable(),
+              integration_id :: Snowflake.resolvable(),
               data ::
                 %{
                   optional(:expire_behavior) => integer(),
@@ -1312,8 +1312,8 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback delete_guild_integration(
-              guild :: Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Guild.id_resolvable(),
+              integration_id :: Snowflake.resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
@@ -1324,39 +1324,39 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback sync_guild_integration(
-              guild :: Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Guild.id_resolvable(),
+              integration_id :: Snowflake.resolvable()
             ) :: :ok | {:error, term()}
 
   @doc """
     Gets a guild's embed (server widget).
 
-  > Returns a [Guild Embed Object](https://discordapp.com/developers/docs/resources/guild#get-guild-embed).
+  > Returns a [Guild Embed Object](https://discordapp.com/developers/docs/resources/guild#guild-embed-object).
 
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/guild#get-guild-embed).
   """
   Version.since("0.2.0")
 
-  @callback get_guild_embed(guild :: Util.guild_id_resolvable()) ::
+  @callback get_guild_embed(guild :: Guild.id_resolvable()) ::
               {:ok, term()} | {:error, term()}
 
   @doc """
     Modifies a guild's embed (server widget).
 
-  > Returns the updated [Guild Embed Object](https://discordapp.com/developers/docs/resources/guild#get-guild-embed).
+  > Returns the updated [Guild Embed Object](https://discordapp.com/developers/docs/resources/guild#guild-embed-object).
 
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/guild#modify-guild-embed).
   """
   Version.since("0.2.0")
 
   @callback modify_guild_embed(
-              guild :: Util.guild_id_resolvable(),
+              guild :: Guild.id_resolvable(),
               data ::
                 %{
                   optional(:enabled) => boolean(),
-                  optional(:channel_id) => Crux.Rest.snowflake()
+                  optional(:channel_id) => Channel.id_resolvable()
                 }
-                | [{:enabled, boolean()} | {:channel_id, Crux.Rest.snowflake()}]
+                | [{:enabled, boolean()} | {:channel_id, Channel.id_resolvable()}]
             ) :: {:ok, term()} | {:error, term()}
 
   @doc """
@@ -1364,7 +1364,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_guild_vanity_url(guild :: Util.guild_id_resolvable()) ::
+  @callback get_guild_vanity_url(guild :: Guild.id_resolvable()) ::
               {:ok, String.t()} | {:error, term()}
 
   ### End Guild
@@ -1378,8 +1378,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback list_guild_webhooks(guild :: Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Webhook.t()}} | {:error, term()}
+  @callback list_guild_webhooks(guild :: Guild.id_resolvable()) ::
+              {:ok, %{required(Snowflake.t()) => Webhook.t()}} | {:error, term()}
 
   @doc """
     Gets a channel's webhook list
@@ -1388,8 +1388,8 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback list_channel_webhooks(channel :: Util.channel_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Webhook.t()}} | {:error, term()}
+  @callback list_channel_webhooks(channel :: Channel.id_resolvable()) ::
+              {:ok, %{required(Snowflake.t()) => Webhook.t()}} | {:error, term()}
 
   @doc """
     Gets a webhook
@@ -1398,7 +1398,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_webhook(user :: Util.user_id_resolvable(), token :: String.t() | nil) ::
+  @callback get_webhook(user :: User.id_resolvable(), token :: String.t() | nil) ::
               {:ok, Webhook.t()} | {:error, term()}
 
   @doc """
@@ -1409,18 +1409,18 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback update_webhook(
-              user :: Util.user_id_resolvable(),
+              user :: User.id_resolvable(),
               token :: String.t() | nil,
               data ::
                 %{
                   optional(:name) => String.t(),
                   optional(:avatar) => Util.image(),
-                  optional(:channel_id) => Crux.Rest.snowflake()
+                  optional(:channel_id) => Channel.id_resolvable()
                 }
                 | [
                     {:name, String.t()}
                     | {:avatar, Util.image()}
-                    | {:channel_id, Crux.Rest.snowflake()}
+                    | {:channel_id, Channel.id_resolvable()}
                   ]
             ) :: {:ok, Webhook.t()} | {:error, term()}
 
@@ -1431,7 +1431,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback delete_webhook(user :: Util.user_id_resolvable(), token :: String.t() | nil) ::
+  @callback delete_webhook(user :: User.id_resolvable(), token :: String.t() | nil) ::
               :ok | {:error, term()}
 
   @typedoc """
@@ -1473,7 +1473,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback execute_webhook(
-              user :: Util.user_id_resolvable(),
+              user :: User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: Crux.Rest.execute_webhook_options()
@@ -1499,7 +1499,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback execute_slack_webhook(
-              user :: Util.user_id_resolvable(),
+              user :: User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: term()
@@ -1530,7 +1530,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback execute_github_webhook(
-              user :: Util.user_id_resolvable(),
+              user :: User.id_resolvable(),
               token :: String.t(),
               event :: String.t(),
               wait :: boolean() | nil,
@@ -1564,7 +1564,7 @@ defmodule Crux.Rest do
   """
   Version.since("0.2.0")
 
-  @callback get_user(user :: Util.user_id_resolvable()) :: {:ok, User.t()} | {:error, term()}
+  @callback get_user(user :: User.id_resolvable()) :: {:ok, User.t()} | {:error, term()}
 
   @doc """
   Gets the current user from the api.
@@ -1597,18 +1597,18 @@ defmodule Crux.Rest do
               {:ok, User.t()} | {:error, term()}
 
   @typedoc """
-    Used to list the current user's guilds in `c:get_current_user_guild_/1`.
+    Used to list the current user's guilds in `c:get_current_user_guild/1`.
   """
   Version.typesince("0.1.4")
 
   @type get_current_user_guild_data :: %{
-          optional(:before) => Crux.Rest.snowflake(),
-          optional(:after) => Crux.Rest.snowflake(),
+          optional(:before) => Message.id_resolvable(),
+          optional(:after) => Message.id_resolvable(),
           optional(:limit) => pos_integer()
         }
 
   @doc """
-  Gets a list of partial `Crux.Structs.Guilds` the current user is a member of.
+  Gets a list of partial `Crux.Structs.Guild`s the current user is a member of.
 
   For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/user#get-current-user-guilds).
   """
@@ -1616,7 +1616,7 @@ defmodule Crux.Rest do
   Version.since("0.2.0")
 
   @callback get_current_user_guilds(data :: Crux.Rest.get_current_user_guild_data()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Guild.t()}} | {:error, term()}
+              {:ok, %{required(Snowflake.t()) => Guild.t()}} | {:error, term()}
 
   @doc """
     Leaves a guild.
@@ -1624,7 +1624,7 @@ defmodule Crux.Rest do
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/user#leave-guild).
   """
   Version.since("0.2.0")
-  @callback leave_guild(guild :: Util.guild_id_resolvable()) :: :ok | {:error, term()}
+  @callback leave_guild(guild :: Guild.id_resolvable()) :: :ok | {:error, term()}
 
   @doc """
     Creates a new dm channel with a user.
@@ -1632,7 +1632,7 @@ defmodule Crux.Rest do
     For more informations see [Discord Docs](https://discordapp.com/developers/docs/resources/user#create-dm).
   """
   Version.since("0.2.0")
-  @callback create_dm(user :: Util.user_id_resolvable()) :: {:ok, Channel.t()} | {:error, term()}
+  @callback create_dm(user :: Guild.id_resolvable()) :: {:ok, Channel.t()} | {:error, term()}
 
   @doc """
     Gets the gateway url from the api.

--- a/lib/rest/gen/bang.ex
+++ b/lib/rest/gen/bang.ex
@@ -11,8 +11,8 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback add_guild_member!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   data :: Crux.Rest.add_guild_member_data()
                 ) :: Member.t() | no_return()
 
@@ -20,29 +20,29 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback add_guild_member_role!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  member :: Crux.Rest.Util.user_id_resolvable(),
-                  role :: Crux.Rest.Util.role_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  member :: Crux.Structs.User.id_resolvable(),
+                  role :: Crux.Structs.Role.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:add_pinned_message/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback add_pinned_message!(message :: Message.t()) :: :ok | no_return()
+      @callback add_pinned_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
 
       @doc "The same as `c:add_pinned_message/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback add_pinned_message!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:begin_guild_prune/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback begin_guild_prune!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   opts :: Crux.Rest.begin_guild_prune_opts()
                 ) :: non_neg_integer() | no_return()
 
@@ -50,26 +50,26 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback create_channel_invite!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
                   args :: Crux.Rest.create_channel_invite_data()
                 ) :: Invite.t() | no_return()
 
       @doc "The same as `c:create_dm/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback create_dm!(user :: Crux.Rest.Util.user_id_resolvable()) ::
-                  Channel.t() | no_return()
+      @callback create_dm!(user :: Crux.Structs.Guild.id_resolvable()) ::
+                  Crux.Structs.Channel.t() | no_return()
 
       @doc "The same as `c:create_guild/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback create_guild!(term()) :: Guild.t() | no_return()
+      @callback create_guild!(term()) :: Crux.Structs.Guild.t() | no_return()
 
       @doc "The same as `c:create_guild_ban/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_guild_ban!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
@@ -77,105 +77,108 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback create_guild_channel!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.create_guild_channel_data()
-                ) :: Channel.t() | no_return()
+                ) :: Crux.Structs.Channel.t() | no_return()
 
       @doc "The same as `c:create_guild_emoji/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_guild_emoji!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.create_guild_emoji_data()
-                ) :: Emoji | no_return()
+                ) :: Crux.Structs.Emoji | no_return()
 
       @doc "The same as `c:create_guild_integration/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_guild_integration!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data ::
-                    %{required(:type) => String.t(), required(:id) => Crux.Rest.snowflake()}
-                    | [{:type, String.t()} | {:id, Crux.Rest.snowflake()}]
+                    %{
+                      required(:type) => String.t(),
+                      required(:id) => Crux.Structs.Snowflake.resolvable()
+                    }
+                    | [{:type, String.t()} | {:id, Crux.Structs.Snowflake.resolvable()}]
                 ) :: :ok | no_return()
 
       @doc "The same as `c:create_guild_role/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_guild_role!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.guild_role_data()
-                ) :: Role.t() | no_return()
+                ) :: Crux.Structs.Role.t() | no_return()
 
       @doc "The same as `c:create_message/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_message!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
                   args :: Crux.Rest.create_message_data()
-                ) :: Message.t() | no_return()
+                ) :: Crux.Structs.Message.t() | no_return()
 
       @doc "The same as `c:create_reaction/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_reaction!(
-                  message :: Crux.Rest.Util.message_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+                  message :: Crux.Structs.Message.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:create_reaction/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback create_reaction!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_id_resolvable()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.id_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_all_reactions/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_all_reactions!(
-                  message :: Message.t(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+                  message :: Crux.Structs.Message.t(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_all_reactions/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_all_reactions!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_channel/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_channel!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
                   reason :: String.t()
-                ) :: Channel.t() | no_return()
+                ) :: Crux.Structs.Channel.t() | no_return()
 
       @doc "The same as `c:delete_channel_permissions/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_channel_permissions!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  target :: Crux.Rest.Util.overwrite_target_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  target :: Crux.Structs.Overwrite.target_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_guild/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback delete_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | no_return()
+      @callback delete_guild!(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | no_return()
 
       @doc "The same as `c:delete_guild_emoji/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_guild_emoji!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
@@ -183,16 +186,16 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback delete_guild_integration!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  integration_id :: Crux.Rest.snowflake()
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  integration_id :: Crux.Structs.Snowflake.resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_guild_role/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_guild_role!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  role :: Crux.Rest.Util.role_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  role :: Crux.Structs.Role.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
@@ -204,51 +207,51 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:delete_message/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback delete_message!(message :: Message.t()) :: :ok | no_return()
+      @callback delete_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
 
       @doc "The same as `c:delete_message/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_message!(
-                  channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-                  message_id :: Crux.Rest.Util.message_id_resolvable()
+                  channel_id :: Crux.Structs.Channel.id_resolvable(),
+                  message_id :: Crux.Structs.Message.id_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_messages/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_messages!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  messages :: [Crux.Rest.Util.message_id_resolvable()]
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  messages :: [Crux.Structs.Message.id_resolvable()]
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_pinned_message/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback delete_pinned_message!(message :: Message.t()) :: :ok | no_return()
+      @callback delete_pinned_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
 
       @doc "The same as `c:delete_pinned_message/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_pinned_message!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_reaction/4`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_reaction!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:delete_webhook/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback delete_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   token :: String.t() | nil
                 ) :: :ok | no_return()
 
@@ -256,25 +259,27 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback edit_channel_permissions!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  target :: Crux.Rest.Util.overwrite_target_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  target :: Crux.Structs.Overwrite.target_resolvable(),
                   data :: Crux.Rest.edit_channel_permissions_data()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:edit_message/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback edit_message!(target :: Message.t(), args :: Crux.Rest.message_edit_data()) ::
-                  Message.t() | no_return()
+      @callback edit_message!(
+                  target :: Crux.Structs.Message.t(),
+                  args :: Crux.Rest.message_edit_data()
+                ) :: Crux.Structs.Message.t() | no_return()
 
       @doc "The same as `c:edit_message/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback edit_message!(
-                  channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-                  message_id :: Crux.Rest.Util.message_id_resolvable(),
+                  channel_id :: Crux.Structs.Channel.id_resolvable(),
+                  message_id :: Crux.Structs.Message.id_resolvable(),
                   args :: Crux.Rest.message_edit_data()
-                ) :: Message.t() | no_return()
+                ) :: Crux.Structs.Message.t() | no_return()
 
       @doc "The same as `c:execute_github_webhook/3`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -299,7 +304,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback execute_github_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   token :: String.t(),
                   event :: String.t(),
                   wait :: boolean() | nil,
@@ -325,7 +330,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback execute_slack_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   token :: String.t(),
                   wait :: boolean() | nil,
                   data :: term()
@@ -352,7 +357,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback execute_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   token :: String.t(),
                   wait :: boolean() | nil,
                   data :: Crux.Rest.execute_webhook_options()
@@ -370,55 +375,59 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback get_audit_logs!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   options :: Crux.Rest.audit_log_options() | nil
                 ) :: AuditLog.t() | no_return()
 
       @doc "The same as `c:get_channel/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_channel!(channel :: Crux.Rest.Util.resolve_channel_id()) ::
-                  Channel.t() | no_return()
+      @callback get_channel!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+                  Crux.Structs.Channel.t() | no_return()
 
       @doc "The same as `c:get_channel_invites/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_channel_invites!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
+      @callback get_channel_invites!(channel :: Crux.Structs.Channel.id_resolvable()) ::
                   %{required(String.t()) => Invite.t()} | no_return()
 
       @doc "The same as `c:get_current_user/0`, but raises an exception if it fails."
       Version.since("0.2.1")
-      @callback get_current_user!() :: User.t() | no_return()
+      @callback get_current_user!() :: Crux.Structs.User.t() | no_return()
 
       @doc "The same as `c:get_current_user_guilds/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_current_user_guilds!(data :: Crux.Rest.get_current_user_guild_data()) ::
-                  %{required(Crux.Rest.snowflake()) => Guild.t()} | no_return()
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}
+                  | no_return()
 
       @doc "The same as `c:get_guild/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-                  Guild.t() | no_return()
+      @callback get_guild!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+                  Crux.Structs.Guild.t() | no_return()
 
       @doc "The same as `c:get_guild_ban/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_guild_ban!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable()
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable()
                 ) ::
-                  %{required(:user) => User.t(), required(:reason) => String.t() | nil}
+                  %{
+                    required(:user) => Crux.Structs.User.t(),
+                    required(:reason) => String.t() | nil
+                  }
                   | no_return()
 
       @doc "The same as `c:get_guild_bans/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_bans!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_bans!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   %{
-                    required(Crux.Rest.snowflake()) => %{
-                      required(:user) => User.t(),
+                    required(Crux.Structs.Snowflake.resolvable()) => %{
+                      required(:user) => Crux.Structs.User.t(),
                       required(:reason) => String.t() | nil
                     }
                   }
@@ -427,67 +436,69 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:get_guild_channels/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_channels!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Channel.t()} | no_return()
+      @callback get_guild_channels!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}
+                  | no_return()
 
       @doc "The same as `c:get_guild_embed/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_embed!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_embed!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   term() | no_return()
 
       @doc "The same as `c:get_guild_emoji/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_guild_emoji!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_id_resolvable()
-                ) :: Emoji | no_return()
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.id_resolvable()
+                ) :: Crux.Structs.Emoji | no_return()
 
       @doc "The same as `c:get_guild_integrations/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_integrations!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_integrations!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   list() | no_return()
 
       @doc "The same as `c:get_guild_invites/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_invites!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_invites!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   %{required(String.t()) => Invite.t()} | no_return()
 
       @doc "The same as `c:get_guild_member/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_guild_member!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable()
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable()
                 ) :: Member.t() | no_return()
 
       @doc "The same as `c:get_guild_prune_count/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_guild_prune_count!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   days :: pos_integer()
                 ) :: non_neg_integer() | no_return()
 
       @doc "The same as `c:get_guild_roles/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_roles!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Role.t()} | no_return()
+      @callback get_guild_roles!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
+                  | no_return()
 
       @doc "The same as `c:get_guild_vanity_url/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_vanity_url!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_vanity_url!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   String.t() | no_return()
 
       @doc "The same as `c:get_guild_voice_regions/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_guild_voice_regions!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @callback get_guild_voice_regions!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   term() | no_return()
 
       @doc "The same as `c:get_invite/1`, but raises an exception if it fails."
@@ -498,104 +509,112 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback get_message!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message_id :: Crux.Rest.Util.message_id_resolvable()
-                ) :: Message | no_return()
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message_id :: Crux.Structs.Message.id_resolvable()
+                ) :: Crux.Structs.Message | no_return()
 
       @doc "The same as `c:get_messages/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_messages!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
                   args :: Crux.Rest.get_messages_data()
-                ) :: %{required(Crux.Rest.snowflake()) => Message.t()} | no_return()
+                ) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+                  | no_return()
 
       @doc "The same as `c:get_pinned_messages/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_pinned_messages!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Message.t()} | no_return()
+      @callback get_pinned_messages!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+                  | no_return()
 
       @doc "The same as `c:get_reactions/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_reactions!(
-                  message :: Message.t(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
+                  message :: Crux.Structs.Message.t(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable(),
                   args :: Crux.Rest.get_reactions_data()
-                ) :: %{required(Crux.Rest.snowflake()) => User.t()} | no_return()
+                ) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
+                  | no_return()
 
       @doc "The same as `c:get_reactions/4`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_reactions!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
-                  message :: Crux.Rest.Util.message_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
+                  message :: Crux.Structs.Message.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.identifier_resolvable(),
                   args :: Crux.Rest.get_reactions_data()
-                ) :: %{required(Crux.Rest.snowflake()) => User.t()} | no_return()
+                ) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
+                  | no_return()
 
       @doc "The same as `c:get_user/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback get_user!(user :: Crux.Rest.Util.user_id_resolvable()) :: User.t() | no_return()
+
+      @callback get_user!(user :: Crux.Structs.User.id_resolvable()) ::
+                  Crux.Structs.User.t() | no_return()
 
       @doc "The same as `c:get_webhook/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback get_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
-                  token :: String.t() | nil
-                ) :: Webhook.t() | no_return()
+      @callback get_webhook!(user :: Crux.Structs.User.id_resolvable(), token :: String.t() | nil) ::
+                  Webhook.t() | no_return()
 
       @doc "The same as `c:leave_guild/1`, but raises an exception if it fails."
       Version.since("0.2.0")
-      @callback leave_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | no_return()
+      @callback leave_guild!(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | no_return()
 
       @doc "The same as `c:list_channel_webhooks/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback list_channel_webhooks!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Webhook.t()} | no_return()
+      @callback list_channel_webhooks!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
 
       @doc "The same as `c:list_guild_emojis/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback list_guild_emojis!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Emoji.t()} | no_return()
+      @callback list_guild_emojis!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}
+                  | no_return()
 
       @doc "The same as `c:list_guild_members/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback list_guild_members!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   options :: Crux.Rest.list_guild_members_options()
-                ) :: %{required(Crux.Rest.snowflake()) => Member.t()} | no_return()
+                ) :: %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()} | no_return()
 
       @doc "The same as `c:list_guild_webhooks/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback list_guild_webhooks!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-                  %{required(Crux.Rest.snowflake()) => Webhook.t()} | no_return()
+      @callback list_guild_webhooks!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
 
       @doc "The same as `c:modify_channel/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_channel!(
-                  channel :: Crux.Rest.Util.channel_id_resolvable(),
+                  channel :: Crux.Structs.Channel.id_resolvable(),
                   data :: Crux.Rest.modify_channel_data()
-                ) :: Channel.t() | no_return()
+                ) :: Crux.Structs.Channel.t() | no_return()
 
       @doc "The same as `c:modify_current_user/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_current_user!(data :: Crux.Rest.modify_current_user_data()) ::
-                  User.t() | no_return()
+                  Crux.Structs.User.t() | no_return()
 
       @doc "The same as `c:modify_current_users_nick/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_current_users_nick!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   nick :: String.t(),
                   reason :: String.t()
                 ) :: :ok | no_return()
@@ -604,15 +623,15 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback modify_guild!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.modify_guild_data()
-                ) :: Guild.t() | no_return()
+                ) :: Crux.Structs.Guild.t() | no_return()
 
       @doc "The same as `c:modify_guild_channel_positions/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_guild_channel_positions!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
                 ) :: :ok | no_return()
 
@@ -620,30 +639,30 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback modify_guild_embed!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data ::
                     %{
                       optional(:enabled) => boolean(),
-                      optional(:channel_id) => Crux.Rest.snowflake()
+                      optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
                     }
-                    | [{:enabled, boolean()} | {:channel_id, Crux.Rest.snowflake()}]
+                    | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
                 ) :: term() | no_return()
 
       @doc "The same as `c:modify_guild_emoji/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_guild_emoji!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  emoji :: Crux.Structs.Emoji.id_resolvable(),
                   data :: Crux.Rest.modify_guild_emoji_data()
-                ) :: Emoji | no_return()
+                ) :: Crux.Structs.Emoji | no_return()
 
       @doc "The same as `c:modify_guild_integration/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_guild_integration!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  integration_id :: Crux.Rest.snowflake(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  integration_id :: Crux.Structs.Snowflake.resolvable(),
                   data ::
                     %{
                       optional(:expire_behavior) => integer(),
@@ -661,8 +680,8 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback modify_guild_member!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  member :: Crux.Rest.Util.user_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  member :: Crux.Structs.User.id_resolvable(),
                   data :: Crux.Rest.modify_guild_member_data()
                 ) :: :ok | no_return()
 
@@ -670,25 +689,27 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback modify_guild_role!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  role :: Crux.Rest.Util.role_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  role :: Crux.Structs.Role.id_resolvable(),
                   data :: Crux.Rest.guild_role_data()
-                ) :: Role.t() | no_return()
+                ) :: Crux.Structs.Role.t() | no_return()
 
       @doc "The same as `c:modify_guild_role_positions/2`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback modify_guild_role_positions!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.Util.modify_guild_role_positions_data()
-                ) :: %{required(Crux.Rest.snowflake()) => Role.t()} | no_return()
+                ) ::
+                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
+                  | no_return()
 
       @doc "The same as `c:remove_guild_ban/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback remove_guild_ban!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
@@ -696,9 +717,9 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback remove_guild_member_role!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  member :: Crux.Rest.Util.user_id_resolvable(),
-                  role :: Crux.Rest.Util.role_id_resolvable(),
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  member :: Crux.Structs.User.id_resolvable(),
+                  role :: Crux.Structs.Role.id_resolvable(),
                   reason :: String.t()
                 ) :: :ok | no_return()
 
@@ -706,32 +727,32 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback sync_guild_integration!(
-                  guild :: Crux.Rest.Util.guild_id_resolvable(),
-                  integration_id :: Crux.Rest.snowflake()
+                  guild :: Crux.Structs.Guild.id_resolvable(),
+                  integration_id :: Crux.Structs.Snowflake.resolvable()
                 ) :: :ok | no_return()
 
       @doc "The same as `c:trigger_typing/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
-      @callback trigger_typing!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
+      @callback trigger_typing!(channel :: Crux.Structs.Channel.id_resolvable()) ::
                   :ok | no_return()
 
       @doc "The same as `c:update_webhook/3`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback update_webhook!(
-                  user :: Crux.Rest.Util.user_id_resolvable(),
+                  user :: Crux.Structs.User.id_resolvable(),
                   token :: String.t() | nil,
                   data ::
                     %{
                       optional(:name) => String.t(),
                       optional(:avatar) => Crux.Rest.Util.image(),
-                      optional(:channel_id) => Crux.Rest.snowflake()
+                      optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
                     }
                     | [
                         {:name, String.t()}
                         | {:avatar, Crux.Rest.Util.image()}
-                        | {:channel_id, Crux.Rest.snowflake()}
+                        | {:channel_id, Crux.Structs.Snowflake.resolvable()}
                       ]
                 ) :: Webhook.t() | no_return()
 
@@ -837,8 +858,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.add_guild_member/3`"
 
       @spec add_guild_member(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               data :: Crux.Rest.add_guild_member_data()
             ) :: {:ok, Member.t()} | {:error, term()}
       def add_guild_member(guild, user, data) do
@@ -849,8 +870,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.add_guild_member/3`, but raises an exception if it fails."
 
       @spec add_guild_member!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               data :: Crux.Rest.add_guild_member_data()
             ) :: Member.t() | no_return()
       def add_guild_member!(guild, user, data) do
@@ -861,32 +882,32 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.add_guild_member_role/4`"
 
       @spec add_guild_member_role(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
-      def add_guild_member_role(guild, member, role, reason) do
-        request = Crux.Rest.Functions.add_guild_member_role(guild, member, role, reason)
+      def add_guild_member_role(guild, user, role, reason) do
+        request = Crux.Rest.Functions.add_guild_member_role(guild, user, role, reason)
         request(request)
       end
 
       @doc "The same as `c:Crux.Rest.add_guild_member_role/4`, but raises an exception if it fails."
 
       @spec add_guild_member_role!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
-      def add_guild_member_role!(guild, member, role, reason) do
-        request = Crux.Rest.Functions.add_guild_member_role(guild, member, role, reason)
+      def add_guild_member_role!(guild, user, role, reason) do
+        request = Crux.Rest.Functions.add_guild_member_role(guild, user, role, reason)
         request!(request)
       end
 
       @doc "See `c:Crux.Rest.add_pinned_message/1`"
 
-      @spec add_pinned_message(message :: Message.t()) :: :ok | {:error, term()}
+      @spec add_pinned_message(message :: Crux.Structs.Message.t()) :: :ok | {:error, term()}
       def add_pinned_message(map) do
         request = Crux.Rest.Functions.add_pinned_message(map)
         request(request)
@@ -894,7 +915,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.add_pinned_message/1`, but raises an exception if it fails."
 
-      @spec add_pinned_message!(message :: Message.t()) :: :ok | no_return()
+      @spec add_pinned_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
       def add_pinned_message!(map) do
         request = Crux.Rest.Functions.add_pinned_message(map)
         request!(request)
@@ -903,8 +924,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.add_pinned_message/2`"
 
       @spec add_pinned_message(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | {:error, term()}
       def add_pinned_message(channel, message) do
         request = Crux.Rest.Functions.add_pinned_message(channel, message)
@@ -914,8 +935,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.add_pinned_message/2`, but raises an exception if it fails."
 
       @spec add_pinned_message!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | no_return()
       def add_pinned_message!(channel, message) do
         request = Crux.Rest.Functions.add_pinned_message(channel, message)
@@ -925,7 +946,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.begin_guild_prune/2`"
 
       @spec begin_guild_prune(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               opts :: Crux.Rest.begin_guild_prune_opts()
             ) :: {:ok, non_neg_integer()} | {:error, term()}
       def begin_guild_prune(guild, data) do
@@ -936,7 +957,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.begin_guild_prune/2`, but raises an exception if it fails."
 
       @spec begin_guild_prune!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               opts :: Crux.Rest.begin_guild_prune_opts()
             ) :: non_neg_integer() | no_return()
       def begin_guild_prune!(guild, data) do
@@ -947,7 +968,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_channel_invite/2`"
 
       @spec create_channel_invite(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.create_channel_invite_data()
             ) :: {:ok, Invite.t()} | {:error, term()}
       def create_channel_invite(channel, data) do
@@ -958,7 +979,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_channel_invite/2`, but raises an exception if it fails."
 
       @spec create_channel_invite!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.create_channel_invite_data()
             ) :: Invite.t() | no_return()
       def create_channel_invite!(channel, data) do
@@ -968,8 +989,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.create_dm/1`"
 
-      @spec create_dm(user :: Crux.Rest.Util.user_id_resolvable()) ::
-              {:ok, Channel.t()} | {:error, term()}
+      @spec create_dm(user :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, Crux.Structs.Channel.t()} | {:error, term()}
       def create_dm(user) do
         request = Crux.Rest.Functions.create_dm(user)
         request(request)
@@ -977,7 +998,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.create_dm/1`, but raises an exception if it fails."
 
-      @spec create_dm!(user :: Crux.Rest.Util.user_id_resolvable()) :: Channel.t() | no_return()
+      @spec create_dm!(user :: Crux.Structs.Guild.id_resolvable()) ::
+              Crux.Structs.Channel.t() | no_return()
       def create_dm!(user) do
         request = Crux.Rest.Functions.create_dm(user)
         request!(request)
@@ -985,7 +1007,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.create_guild/1`"
 
-      @spec create_guild(term()) :: {:ok, Guild.t()} | {:error, term()}
+      @spec create_guild(term()) :: {:ok, Crux.Structs.Guild.t()} | {:error, term()}
       def create_guild(data) do
         request = Crux.Rest.Functions.create_guild(data)
         request(request)
@@ -993,7 +1015,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.create_guild/1`, but raises an exception if it fails."
 
-      @spec create_guild!(term()) :: Guild.t() | no_return()
+      @spec create_guild!(term()) :: Crux.Structs.Guild.t() | no_return()
       def create_guild!(data) do
         request = Crux.Rest.Functions.create_guild(data)
         request!(request)
@@ -1002,8 +1024,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_guild_ban/3`"
 
       @spec create_guild_ban(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
       def create_guild_ban(guild, user, reason \\ nil) do
@@ -1014,8 +1036,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_guild_ban/3`, but raises an exception if it fails."
 
       @spec create_guild_ban!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
       def create_guild_ban!(guild, user, reason \\ nil) do
@@ -1026,9 +1048,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_guild_channel/2`"
 
       @spec create_guild_channel(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_channel_data()
-            ) :: {:ok, Channel.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Channel.t()} | {:error, term()}
       def create_guild_channel(guild, data) do
         request = Crux.Rest.Functions.create_guild_channel(guild, data)
         request(request)
@@ -1037,9 +1059,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_guild_channel/2`, but raises an exception if it fails."
 
       @spec create_guild_channel!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_channel_data()
-            ) :: Channel.t() | no_return()
+            ) :: Crux.Structs.Channel.t() | no_return()
       def create_guild_channel!(guild, data) do
         request = Crux.Rest.Functions.create_guild_channel(guild, data)
         request!(request)
@@ -1048,9 +1070,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_guild_emoji/2`"
 
       @spec create_guild_emoji(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_emoji_data()
-            ) :: {:ok, Emoji} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Emoji} | {:error, term()}
       def create_guild_emoji(guild, data) do
         request = Crux.Rest.Functions.create_guild_emoji(guild, data)
         request(request)
@@ -1059,9 +1081,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_guild_emoji/2`, but raises an exception if it fails."
 
       @spec create_guild_emoji!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.create_guild_emoji_data()
-            ) :: Emoji | no_return()
+            ) :: Crux.Structs.Emoji | no_return()
       def create_guild_emoji!(guild, data) do
         request = Crux.Rest.Functions.create_guild_emoji(guild, data)
         request!(request)
@@ -1070,10 +1092,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_guild_integration/2`"
 
       @spec create_guild_integration(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data ::
-                %{required(:type) => String.t(), required(:id) => Crux.Rest.snowflake()}
-                | [{:type, String.t()} | {:id, Crux.Rest.snowflake()}]
+                %{
+                  required(:type) => String.t(),
+                  required(:id) => Crux.Structs.Snowflake.resolvable()
+                }
+                | [{:type, String.t()} | {:id, Crux.Structs.Snowflake.resolvable()}]
             ) :: :ok | {:error, term()}
       def create_guild_integration(guild, data) do
         request = Crux.Rest.Functions.create_guild_integration(guild, data)
@@ -1083,10 +1108,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_guild_integration/2`, but raises an exception if it fails."
 
       @spec create_guild_integration!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data ::
-                %{required(:type) => String.t(), required(:id) => Crux.Rest.snowflake()}
-                | [{:type, String.t()} | {:id, Crux.Rest.snowflake()}]
+                %{
+                  required(:type) => String.t(),
+                  required(:id) => Crux.Structs.Snowflake.resolvable()
+                }
+                | [{:type, String.t()} | {:id, Crux.Structs.Snowflake.resolvable()}]
             ) :: :ok | no_return()
       def create_guild_integration!(guild, data) do
         request = Crux.Rest.Functions.create_guild_integration(guild, data)
@@ -1096,9 +1124,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_guild_role/2`"
 
       @spec create_guild_role(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
-            ) :: {:ok, Role.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Role.t()} | {:error, term()}
       def create_guild_role(guild, data) do
         request = Crux.Rest.Functions.create_guild_role(guild, data)
         request(request)
@@ -1107,9 +1135,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_guild_role/2`, but raises an exception if it fails."
 
       @spec create_guild_role!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
-            ) :: Role.t() | no_return()
+            ) :: Crux.Structs.Role.t() | no_return()
       def create_guild_role!(guild, data) do
         request = Crux.Rest.Functions.create_guild_role(guild, data)
         request!(request)
@@ -1118,9 +1146,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_message/2`"
 
       @spec create_message(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.create_message_data()
-            ) :: {:ok, Message.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Message.t()} | {:error, term()}
       def create_message(channel_or_message, data) do
         request = Crux.Rest.Functions.create_message(channel_or_message, data)
         request(request)
@@ -1129,9 +1157,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_message/2`, but raises an exception if it fails."
 
       @spec create_message!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.create_message_data()
-            ) :: Message.t() | no_return()
+            ) :: Crux.Structs.Message.t() | no_return()
       def create_message!(channel_or_message, data) do
         request = Crux.Rest.Functions.create_message(channel_or_message, data)
         request!(request)
@@ -1140,8 +1168,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_reaction/2`"
 
       @spec create_reaction(
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
       def create_reaction(map, emoji) do
         request = Crux.Rest.Functions.create_reaction(map, emoji)
@@ -1151,8 +1179,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_reaction/2`, but raises an exception if it fails."
 
       @spec create_reaction!(
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | no_return()
       def create_reaction!(map, emoji) do
         request = Crux.Rest.Functions.create_reaction(map, emoji)
@@ -1162,9 +1190,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.create_reaction/3`"
 
       @spec create_reaction(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable()
             ) :: :ok | {:error, term()}
       def create_reaction(channel, message, emoji) do
         request = Crux.Rest.Functions.create_reaction(channel, message, emoji)
@@ -1174,9 +1202,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.create_reaction/3`, but raises an exception if it fails."
 
       @spec create_reaction!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable()
             ) :: :ok | no_return()
       def create_reaction!(channel, message, emoji) do
         request = Crux.Rest.Functions.create_reaction(channel, message, emoji)
@@ -1186,8 +1214,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_all_reactions/2`"
 
       @spec delete_all_reactions(
-              message :: Message.t(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              message :: Crux.Structs.Message.t(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
       def delete_all_reactions(map, emoji) do
         request = Crux.Rest.Functions.delete_all_reactions(map, emoji)
@@ -1197,8 +1225,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_all_reactions/2`, but raises an exception if it fails."
 
       @spec delete_all_reactions!(
-              message :: Message.t(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              message :: Crux.Structs.Message.t(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | no_return()
       def delete_all_reactions!(map, emoji) do
         request = Crux.Rest.Functions.delete_all_reactions(map, emoji)
@@ -1208,9 +1236,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_all_reactions/3`"
 
       @spec delete_all_reactions(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | {:error, term()}
       def delete_all_reactions(channel, message, emoji) do
         request = Crux.Rest.Functions.delete_all_reactions(channel, message, emoji)
@@ -1220,9 +1248,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_all_reactions/3`, but raises an exception if it fails."
 
       @spec delete_all_reactions!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable()
             ) :: :ok | no_return()
       def delete_all_reactions!(channel, message, emoji) do
         request = Crux.Rest.Functions.delete_all_reactions(channel, message, emoji)
@@ -1231,10 +1259,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.delete_channel/2`"
 
-      @spec delete_channel(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              reason :: String.t()
-            ) :: {:ok, Channel.t()} | {:error, term()}
+      @spec delete_channel(channel :: Crux.Structs.Channel.id_resolvable(), reason :: String.t()) ::
+              {:ok, Crux.Structs.Channel.t()} | {:error, term()}
       def delete_channel(channel, reason \\ nil) do
         request = Crux.Rest.Functions.delete_channel(channel, reason)
         request(request)
@@ -1242,10 +1268,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.delete_channel/2`, but raises an exception if it fails."
 
-      @spec delete_channel!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              reason :: String.t()
-            ) :: Channel.t() | no_return()
+      @spec delete_channel!(channel :: Crux.Structs.Channel.id_resolvable(), reason :: String.t()) ::
+              Crux.Structs.Channel.t() | no_return()
       def delete_channel!(channel, reason \\ nil) do
         request = Crux.Rest.Functions.delete_channel(channel, reason)
         request!(request)
@@ -1254,8 +1278,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_channel_permissions/3`"
 
       @spec delete_channel_permissions(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              target :: Crux.Rest.Util.overwrite_target_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              target :: Crux.Structs.Overwrite.target_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
       def delete_channel_permissions(channel, target, reason \\ nil) do
@@ -1266,8 +1290,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_channel_permissions/3`, but raises an exception if it fails."
 
       @spec delete_channel_permissions!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              target :: Crux.Rest.Util.overwrite_target_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              target :: Crux.Structs.Overwrite.target_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
       def delete_channel_permissions!(channel, target, reason \\ nil) do
@@ -1277,7 +1301,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.delete_guild/1`"
 
-      @spec delete_guild(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | {:error, term()}
+      @spec delete_guild(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | {:error, term()}
       def delete_guild(guild) do
         request = Crux.Rest.Functions.delete_guild(guild)
         request(request)
@@ -1285,7 +1309,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.delete_guild/1`, but raises an exception if it fails."
 
-      @spec delete_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | no_return()
+      @spec delete_guild!(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | no_return()
       def delete_guild!(guild) do
         request = Crux.Rest.Functions.delete_guild(guild)
         request!(request)
@@ -1294,8 +1318,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_guild_emoji/3`"
 
       @spec delete_guild_emoji(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
       def delete_guild_emoji(guild, emoji, reason \\ nil) do
@@ -1306,8 +1330,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_guild_emoji/3`, but raises an exception if it fails."
 
       @spec delete_guild_emoji!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
       def delete_guild_emoji!(guild, emoji, reason \\ nil) do
@@ -1318,8 +1342,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_guild_integration/2`"
 
       @spec delete_guild_integration(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable()
             ) :: :ok | {:error, term()}
       def delete_guild_integration(guild, integration) do
         request = Crux.Rest.Functions.delete_guild_integration(guild, integration)
@@ -1329,8 +1353,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_guild_integration/2`, but raises an exception if it fails."
 
       @spec delete_guild_integration!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable()
             ) :: :ok | no_return()
       def delete_guild_integration!(guild, integration) do
         request = Crux.Rest.Functions.delete_guild_integration(guild, integration)
@@ -1340,8 +1364,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_guild_role/3`"
 
       @spec delete_guild_role(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
       def delete_guild_role(guild, role, reason \\ nil) do
@@ -1352,8 +1376,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_guild_role/3`, but raises an exception if it fails."
 
       @spec delete_guild_role!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
       def delete_guild_role!(guild, role, reason \\ nil) do
@@ -1380,7 +1404,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.delete_message/1`"
 
-      @spec delete_message(message :: Message.t()) :: :ok | {:error, term()}
+      @spec delete_message(message :: Crux.Structs.Message.t()) :: :ok | {:error, term()}
       def delete_message(map) do
         request = Crux.Rest.Functions.delete_message(map)
         request(request)
@@ -1388,7 +1412,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.delete_message/1`, but raises an exception if it fails."
 
-      @spec delete_message!(message :: Message.t()) :: :ok | no_return()
+      @spec delete_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
       def delete_message!(map) do
         request = Crux.Rest.Functions.delete_message(map)
         request!(request)
@@ -1397,8 +1421,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_message/2`"
 
       @spec delete_message(
-              channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-              message_id :: Crux.Rest.Util.message_id_resolvable()
+              channel_id :: Crux.Structs.Channel.id_resolvable(),
+              message_id :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | {:error, term()}
       def delete_message(channel, message) do
         request = Crux.Rest.Functions.delete_message(channel, message)
@@ -1408,8 +1432,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_message/2`, but raises an exception if it fails."
 
       @spec delete_message!(
-              channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-              message_id :: Crux.Rest.Util.message_id_resolvable()
+              channel_id :: Crux.Structs.Channel.id_resolvable(),
+              message_id :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | no_return()
       def delete_message!(channel, message) do
         request = Crux.Rest.Functions.delete_message(channel, message)
@@ -1419,8 +1443,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_messages/2`"
 
       @spec delete_messages(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              messages :: [Crux.Rest.Util.message_id_resolvable()]
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              messages :: [Crux.Structs.Message.id_resolvable()]
             ) :: :ok | {:error, term()}
       def delete_messages(channel, messages) do
         request = Crux.Rest.Functions.delete_messages(channel, messages)
@@ -1430,8 +1454,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_messages/2`, but raises an exception if it fails."
 
       @spec delete_messages!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              messages :: [Crux.Rest.Util.message_id_resolvable()]
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              messages :: [Crux.Structs.Message.id_resolvable()]
             ) :: :ok | no_return()
       def delete_messages!(channel, messages) do
         request = Crux.Rest.Functions.delete_messages(channel, messages)
@@ -1440,7 +1464,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.delete_pinned_message/1`"
 
-      @spec delete_pinned_message(message :: Message.t()) :: :ok | {:error, term()}
+      @spec delete_pinned_message(message :: Crux.Structs.Message.t()) :: :ok | {:error, term()}
       def delete_pinned_message(map) do
         request = Crux.Rest.Functions.delete_pinned_message(map)
         request(request)
@@ -1448,7 +1472,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.delete_pinned_message/1`, but raises an exception if it fails."
 
-      @spec delete_pinned_message!(message :: Message.t()) :: :ok | no_return()
+      @spec delete_pinned_message!(message :: Crux.Structs.Message.t()) :: :ok | no_return()
       def delete_pinned_message!(map) do
         request = Crux.Rest.Functions.delete_pinned_message(map)
         request!(request)
@@ -1457,8 +1481,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_pinned_message/2`"
 
       @spec delete_pinned_message(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | {:error, term()}
       def delete_pinned_message(channel, message) do
         request = Crux.Rest.Functions.delete_pinned_message(channel, message)
@@ -1468,8 +1492,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_pinned_message/2`, but raises an exception if it fails."
 
       @spec delete_pinned_message!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable()
             ) :: :ok | no_return()
       def delete_pinned_message!(channel, message) do
         request = Crux.Rest.Functions.delete_pinned_message(channel, message)
@@ -1479,10 +1503,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.delete_reaction/4`"
 
       @spec delete_reaction(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) :: :ok | {:error, term()}
       def delete_reaction(
             message_or_channel,
@@ -1504,10 +1528,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.delete_reaction/4`, but raises an exception if it fails."
 
       @spec delete_reaction!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) :: :ok | no_return()
       def delete_reaction!(
             message_or_channel,
@@ -1528,7 +1552,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.delete_webhook/2`"
 
-      @spec delete_webhook(user :: Crux.Rest.Util.user_id_resolvable(), token :: String.t() | nil) ::
+      @spec delete_webhook(user :: Crux.Structs.User.id_resolvable(), token :: String.t() | nil) ::
               :ok | {:error, term()}
       def delete_webhook(user, token \\ nil) do
         request = Crux.Rest.Functions.delete_webhook(user, token)
@@ -1537,10 +1561,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.delete_webhook/2`, but raises an exception if it fails."
 
-      @spec delete_webhook!(
-              user :: Crux.Rest.Util.user_id_resolvable(),
-              token :: String.t() | nil
-            ) :: :ok | no_return()
+      @spec delete_webhook!(user :: Crux.Structs.User.id_resolvable(), token :: String.t() | nil) ::
+              :ok | no_return()
       def delete_webhook!(user, token \\ nil) do
         request = Crux.Rest.Functions.delete_webhook(user, token)
         request!(request)
@@ -1549,8 +1571,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.edit_channel_permissions/3`"
 
       @spec edit_channel_permissions(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              target :: Crux.Rest.Util.overwrite_target_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              target :: Crux.Structs.Overwrite.target_resolvable(),
               data :: Crux.Rest.edit_channel_permissions_data()
             ) :: :ok | {:error, :missing_target} | {:error, term()}
       def edit_channel_permissions(channel, target, data) do
@@ -1561,8 +1583,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.edit_channel_permissions/3`, but raises an exception if it fails."
 
       @spec edit_channel_permissions!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              target :: Crux.Rest.Util.overwrite_target_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              target :: Crux.Structs.Overwrite.target_resolvable(),
               data :: Crux.Rest.edit_channel_permissions_data()
             ) :: :ok | no_return()
       def edit_channel_permissions!(channel, target, data) do
@@ -1572,8 +1594,10 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.edit_message/2`"
 
-      @spec edit_message(target :: Message.t(), args :: Crux.Rest.message_edit_data()) ::
-              {:ok, Message.t()} | {:error, term()}
+      @spec edit_message(
+              target :: Crux.Structs.Message.t(),
+              args :: Crux.Rest.message_edit_data()
+            ) :: {:ok, Crux.Structs.Message.t()} | {:error, term()}
       def edit_message(map, data) do
         request = Crux.Rest.Functions.edit_message(map, data)
         request(request)
@@ -1581,8 +1605,10 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.edit_message/2`, but raises an exception if it fails."
 
-      @spec edit_message!(target :: Message.t(), args :: Crux.Rest.message_edit_data()) ::
-              Message.t() | no_return()
+      @spec edit_message!(
+              target :: Crux.Structs.Message.t(),
+              args :: Crux.Rest.message_edit_data()
+            ) :: Crux.Structs.Message.t() | no_return()
       def edit_message!(map, data) do
         request = Crux.Rest.Functions.edit_message(map, data)
         request!(request)
@@ -1591,10 +1617,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.edit_message/3`"
 
       @spec edit_message(
-              channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-              message_id :: Crux.Rest.Util.message_id_resolvable(),
+              channel_id :: Crux.Structs.Channel.id_resolvable(),
+              message_id :: Crux.Structs.Message.id_resolvable(),
               args :: Crux.Rest.message_edit_data()
-            ) :: {:ok, Message.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Message.t()} | {:error, term()}
       def edit_message(channel, message, data) do
         request = Crux.Rest.Functions.edit_message(channel, message, data)
         request(request)
@@ -1603,10 +1629,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.edit_message/3`, but raises an exception if it fails."
 
       @spec edit_message!(
-              channel_id :: Crux.Rest.Util.channel_id_resolvable(),
-              message_id :: Crux.Rest.Util.message_id_resolvable(),
+              channel_id :: Crux.Structs.Channel.id_resolvable(),
+              message_id :: Crux.Structs.Message.id_resolvable(),
               args :: Crux.Rest.message_edit_data()
-            ) :: Message.t() | no_return()
+            ) :: Crux.Structs.Message.t() | no_return()
       def edit_message!(channel, message, data) do
         request = Crux.Rest.Functions.edit_message(channel, message, data)
         request!(request)
@@ -1633,7 +1659,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.execute_github_webhook/5`"
 
       @spec execute_github_webhook(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               event :: String.t(),
               wait :: boolean() | nil,
@@ -1647,7 +1673,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.execute_github_webhook/5`, but raises an exception if it fails."
 
       @spec execute_github_webhook!(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               event :: String.t(),
               wait :: boolean() | nil,
@@ -1677,7 +1703,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.execute_slack_webhook/4`"
 
       @spec execute_slack_webhook(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: term()
@@ -1690,7 +1716,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.execute_slack_webhook/4`, but raises an exception if it fails."
 
       @spec execute_slack_webhook!(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: term()
@@ -1721,11 +1747,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.execute_webhook/4`"
 
       @spec execute_webhook(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: Crux.Rest.execute_webhook_options()
-            ) :: :ok | {:ok, Message.t()} | {:error, term()}
+            ) :: :ok | {:ok, Crux.Structs.Message.t()} | {:error, term()}
       def execute_webhook(user, token, wait \\ false, data) do
         request = Crux.Rest.Functions.execute_webhook(user, token, wait, data)
         request(request)
@@ -1734,7 +1760,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.execute_webhook/4`, but raises an exception if it fails."
 
       @spec execute_webhook!(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t(),
               wait :: boolean() | nil,
               data :: Crux.Rest.execute_webhook_options()
@@ -1779,7 +1805,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_audit_logs/2`"
 
       @spec get_audit_logs(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.audit_log_options() | nil
             ) :: {:ok, AuditLog.t()} | {:error, term()}
       def get_audit_logs(guild, data \\ []) do
@@ -1790,7 +1816,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_audit_logs/2`, but raises an exception if it fails."
 
       @spec get_audit_logs!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.audit_log_options() | nil
             ) :: AuditLog.t() | no_return()
       def get_audit_logs!(guild, data \\ []) do
@@ -1800,8 +1826,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_channel/1`"
 
-      @spec get_channel(channel :: Crux.Rest.Util.resolve_channel_id()) ::
-              {:ok, Channel.t()} | {:error, term()}
+      @spec get_channel(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              {:ok, Crux.Structs.Channel.t()} | {:error, term()}
       def get_channel(channel) do
         request = Crux.Rest.Functions.get_channel(channel)
         request(request)
@@ -1809,8 +1835,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_channel/1`, but raises an exception if it fails."
 
-      @spec get_channel!(channel :: Crux.Rest.Util.resolve_channel_id()) ::
-              Channel.t() | no_return()
+      @spec get_channel!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              Crux.Structs.Channel.t() | no_return()
       def get_channel!(channel) do
         request = Crux.Rest.Functions.get_channel(channel)
         request!(request)
@@ -1818,7 +1844,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_channel_invites/1`"
 
-      @spec get_channel_invites(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
+      @spec get_channel_invites(channel :: Crux.Structs.Channel.id_resolvable()) ::
               {:ok, %{required(String.t()) => Invite.t()}} | {:error, term()}
       def get_channel_invites(channel) do
         request = Crux.Rest.Functions.get_channel_invites(channel)
@@ -1827,7 +1853,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_channel_invites/1`, but raises an exception if it fails."
 
-      @spec get_channel_invites!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
+      @spec get_channel_invites!(channel :: Crux.Structs.Channel.id_resolvable()) ::
               %{required(String.t()) => Invite.t()} | no_return()
       def get_channel_invites!(channel) do
         request = Crux.Rest.Functions.get_channel_invites(channel)
@@ -1836,7 +1862,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_current_user/0`"
 
-      @spec get_current_user() :: {:ok, User.t()} | {:error, term()}
+      @spec get_current_user() :: {:ok, Crux.Structs.User.t()} | {:error, term()}
       def get_current_user() do
         request = Crux.Rest.Functions.get_current_user()
         request(request)
@@ -1844,7 +1870,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_current_user/0`, but raises an exception if it fails."
 
-      @spec get_current_user!() :: User.t() | no_return()
+      @spec get_current_user!() :: Crux.Structs.User.t() | no_return()
       def get_current_user!() do
         request = Crux.Rest.Functions.get_current_user()
         request!(request)
@@ -1853,7 +1879,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_current_user_guilds/1`"
 
       @spec get_current_user_guilds(data :: Crux.Rest.get_current_user_guild_data()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Guild.t()}} | {:error, term()}
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}}
+              | {:error, term()}
       def get_current_user_guilds(data) do
         request = Crux.Rest.Functions.get_current_user_guilds(data)
         request(request)
@@ -1862,7 +1889,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_current_user_guilds/1`, but raises an exception if it fails."
 
       @spec get_current_user_guilds!(data :: Crux.Rest.get_current_user_guild_data()) ::
-              %{required(Crux.Rest.snowflake()) => Guild.t()} | no_return()
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}
+              | no_return()
       def get_current_user_guilds!(data) do
         request = Crux.Rest.Functions.get_current_user_guilds(data)
         request!(request)
@@ -1870,8 +1898,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild/1`"
 
-      @spec get_guild(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              {:ok, Guild.t()} | {:error, term()}
+      @spec get_guild(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, Crux.Structs.Guild.t()} | {:error, term()}
       def get_guild(guild) do
         request = Crux.Rest.Functions.get_guild(guild)
         request(request)
@@ -1879,7 +1907,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild/1`, but raises an exception if it fails."
 
-      @spec get_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) :: Guild.t() | no_return()
+      @spec get_guild!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              Crux.Structs.Guild.t() | no_return()
       def get_guild!(guild) do
         request = Crux.Rest.Functions.get_guild(guild)
         request!(request)
@@ -1888,10 +1917,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_ban/2`"
 
       @spec get_guild_ban(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) ::
-              {:ok, %{required(:user) => User.t(), required(:reason) => String.t() | nil}}
+              {:ok,
+               %{required(:user) => Crux.Structs.User.t(), required(:reason) => String.t() | nil}}
               | {:error, term()}
       def get_guild_ban(guild, user) do
         request = Crux.Rest.Functions.get_guild_ban(guild, user)
@@ -1901,10 +1931,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_ban/2`, but raises an exception if it fails."
 
       @spec get_guild_ban!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) ::
-              %{required(:user) => User.t(), required(:reason) => String.t() | nil} | no_return()
+              %{required(:user) => Crux.Structs.User.t(), required(:reason) => String.t() | nil}
+              | no_return()
       def get_guild_ban!(guild, user) do
         request = Crux.Rest.Functions.get_guild_ban(guild, user)
         request!(request)
@@ -1912,11 +1943,11 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_bans/1`"
 
-      @spec get_guild_bans(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_bans(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok,
                %{
-                 required(Crux.Rest.snowflake()) => %{
-                   required(:user) => User.t(),
+                 required(Crux.Structs.Snowflake.resolvable()) => %{
+                   required(:user) => Crux.Structs.User.t(),
                    required(:reason) => String.t() | nil
                  }
                }}
@@ -1928,10 +1959,10 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_bans/1`, but raises an exception if it fails."
 
-      @spec get_guild_bans!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_bans!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               %{
-                required(Crux.Rest.snowflake()) => %{
-                  required(:user) => User.t(),
+                required(Crux.Structs.Snowflake.resolvable()) => %{
+                  required(:user) => Crux.Structs.User.t(),
                   required(:reason) => String.t() | nil
                 }
               }
@@ -1943,8 +1974,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_channels/1`"
 
-      @spec get_guild_channels(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Channel.t()}} | {:error, term()}
+      @spec get_guild_channels(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}}
+              | {:error, term()}
       def get_guild_channels(guild) do
         request = Crux.Rest.Functions.get_guild_channels(guild)
         request(request)
@@ -1952,8 +1984,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_channels/1`, but raises an exception if it fails."
 
-      @spec get_guild_channels!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Channel.t()} | no_return()
+      @spec get_guild_channels!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}
+              | no_return()
       def get_guild_channels!(guild) do
         request = Crux.Rest.Functions.get_guild_channels(guild)
         request!(request)
@@ -1961,7 +1994,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_embed/1`"
 
-      @spec get_guild_embed(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_embed(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok, term()} | {:error, term()}
       def get_guild_embed(guild) do
         request = Crux.Rest.Functions.get_guild_embed(guild)
@@ -1970,8 +2003,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_embed/1`, but raises an exception if it fails."
 
-      @spec get_guild_embed!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              term() | no_return()
+      @spec get_guild_embed!(guild :: Crux.Structs.Guild.id_resolvable()) :: term() | no_return()
       def get_guild_embed!(guild) do
         request = Crux.Rest.Functions.get_guild_embed(guild)
         request!(request)
@@ -1980,9 +2012,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_emoji/2`"
 
       @spec get_guild_emoji(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable()
-            ) :: {:ok, Emoji} | {:error, term()}
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable()
+            ) :: {:ok, Crux.Structs.Emoji} | {:error, term()}
       def get_guild_emoji(guild, emoji) do
         request = Crux.Rest.Functions.get_guild_emoji(guild, emoji)
         request(request)
@@ -1991,9 +2023,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_emoji/2`, but raises an exception if it fails."
 
       @spec get_guild_emoji!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable()
-            ) :: Emoji | no_return()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable()
+            ) :: Crux.Structs.Emoji | no_return()
       def get_guild_emoji!(guild, emoji) do
         request = Crux.Rest.Functions.get_guild_emoji(guild, emoji)
         request!(request)
@@ -2001,7 +2033,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_integrations/1`"
 
-      @spec get_guild_integrations(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_integrations(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok, list()} | {:error, term()}
       def get_guild_integrations(guild) do
         request = Crux.Rest.Functions.get_guild_integrations(guild)
@@ -2010,7 +2042,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_integrations/1`, but raises an exception if it fails."
 
-      @spec get_guild_integrations!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_integrations!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               list() | no_return()
       def get_guild_integrations!(guild) do
         request = Crux.Rest.Functions.get_guild_integrations(guild)
@@ -2019,7 +2051,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_invites/1`"
 
-      @spec get_guild_invites(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_invites(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok, %{required(String.t()) => Invite.t()}} | {:error, term()}
       def get_guild_invites(guild) do
         request = Crux.Rest.Functions.get_guild_invites(guild)
@@ -2028,7 +2060,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_invites/1`, but raises an exception if it fails."
 
-      @spec get_guild_invites!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_invites!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               %{required(String.t()) => Invite.t()} | no_return()
       def get_guild_invites!(guild) do
         request = Crux.Rest.Functions.get_guild_invites(guild)
@@ -2038,8 +2070,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_member/2`"
 
       @spec get_guild_member(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) :: {:ok, Member.t()} | {:error, term()}
       def get_guild_member(guild, user) do
         request = Crux.Rest.Functions.get_guild_member(guild, user)
@@ -2049,8 +2081,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_member/2`, but raises an exception if it fails."
 
       @spec get_guild_member!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable()
             ) :: Member.t() | no_return()
       def get_guild_member!(guild, user) do
         request = Crux.Rest.Functions.get_guild_member(guild, user)
@@ -2060,7 +2092,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_prune_count/2`"
 
       @spec get_guild_prune_count(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               days :: pos_integer()
             ) :: {:ok, non_neg_integer()} | {:error, term()}
       def get_guild_prune_count(guild, days) do
@@ -2071,7 +2103,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_prune_count/2`, but raises an exception if it fails."
 
       @spec get_guild_prune_count!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               days :: pos_integer()
             ) :: non_neg_integer() | no_return()
       def get_guild_prune_count!(guild, days) do
@@ -2081,8 +2113,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_roles/1`"
 
-      @spec get_guild_roles(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Role.t()}} | {:error, term()}
+      @spec get_guild_roles(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}}
+              | {:error, term()}
       def get_guild_roles(guild) do
         request = Crux.Rest.Functions.get_guild_roles(guild)
         request(request)
@@ -2090,8 +2123,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_roles/1`, but raises an exception if it fails."
 
-      @spec get_guild_roles!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Role.t()} | no_return()
+      @spec get_guild_roles!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
+              | no_return()
       def get_guild_roles!(guild) do
         request = Crux.Rest.Functions.get_guild_roles(guild)
         request!(request)
@@ -2099,7 +2133,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_vanity_url/1`"
 
-      @spec get_guild_vanity_url(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_vanity_url(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok, String.t()} | {:error, term()}
       def get_guild_vanity_url(guild) do
         request = Crux.Rest.Functions.get_guild_vanity_url(guild)
@@ -2108,7 +2142,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_vanity_url/1`, but raises an exception if it fails."
 
-      @spec get_guild_vanity_url!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_vanity_url!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               String.t() | no_return()
       def get_guild_vanity_url!(guild) do
         request = Crux.Rest.Functions.get_guild_vanity_url(guild)
@@ -2117,7 +2151,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_guild_voice_regions/1`"
 
-      @spec get_guild_voice_regions(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_voice_regions(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok, term()} | {:error, term()}
       def get_guild_voice_regions(guild) do
         request = Crux.Rest.Functions.get_guild_voice_regions(guild)
@@ -2126,7 +2160,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_guild_voice_regions/1`, but raises an exception if it fails."
 
-      @spec get_guild_voice_regions!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
+      @spec get_guild_voice_regions!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               term() | no_return()
       def get_guild_voice_regions!(guild) do
         request = Crux.Rest.Functions.get_guild_voice_regions(guild)
@@ -2174,9 +2208,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_messages/2`"
 
       @spec get_messages(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.get_messages_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => Message.t()}} | {:error, term()}
+            ) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}}
+              | {:error, term()}
       def get_messages(channel, data) do
         request = Crux.Rest.Functions.get_messages(channel, data)
         request(request)
@@ -2185,9 +2221,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_messages/2`, but raises an exception if it fails."
 
       @spec get_messages!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.get_messages_data()
-            ) :: %{required(Crux.Rest.snowflake()) => Message.t()} | no_return()
+            ) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+              | no_return()
       def get_messages!(channel, data) do
         request = Crux.Rest.Functions.get_messages(channel, data)
         request!(request)
@@ -2195,8 +2233,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_pinned_messages/1`"
 
-      @spec get_pinned_messages(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Message.t()}} | {:error, term()}
+      @spec get_pinned_messages(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}}
+              | {:error, term()}
       def get_pinned_messages(channel) do
         request = Crux.Rest.Functions.get_pinned_messages(channel)
         request(request)
@@ -2204,8 +2243,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_pinned_messages/1`, but raises an exception if it fails."
 
-      @spec get_pinned_messages!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Message.t()} | no_return()
+      @spec get_pinned_messages!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+              | no_return()
       def get_pinned_messages!(channel) do
         request = Crux.Rest.Functions.get_pinned_messages(channel)
         request!(request)
@@ -2214,11 +2254,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_reactions/4`"
 
       @spec get_reactions(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => User.t()}} | {:error, term()}
+            ) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}}
+              | {:error, term()}
       def get_reactions(
             channel_or_message,
             emoji_or_message_id,
@@ -2239,11 +2281,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_reactions/4`, but raises an exception if it fails."
 
       @spec get_reactions!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
-              message :: Crux.Rest.Util.message_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_identifier_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
+              message :: Crux.Structs.Message.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
-            ) :: %{required(Crux.Rest.snowflake()) => User.t()} | no_return()
+            ) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
+              | no_return()
       def get_reactions!(
             channel_or_message,
             emoji_or_message_id,
@@ -2263,8 +2307,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_user/1`"
 
-      @spec get_user(user :: Crux.Rest.Util.user_id_resolvable()) ::
-              {:ok, User.t()} | {:error, term()}
+      @spec get_user(user :: Crux.Structs.User.id_resolvable()) ::
+              {:ok, Crux.Structs.User.t()} | {:error, term()}
       def get_user(user) do
         request = Crux.Rest.Functions.get_user(user)
         request(request)
@@ -2272,7 +2316,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_user/1`, but raises an exception if it fails."
 
-      @spec get_user!(user :: Crux.Rest.Util.user_id_resolvable()) :: User.t() | no_return()
+      @spec get_user!(user :: Crux.Structs.User.id_resolvable()) ::
+              Crux.Structs.User.t() | no_return()
       def get_user!(user) do
         request = Crux.Rest.Functions.get_user(user)
         request!(request)
@@ -2280,7 +2325,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.get_webhook/2`"
 
-      @spec get_webhook(user :: Crux.Rest.Util.user_id_resolvable(), token :: String.t() | nil) ::
+      @spec get_webhook(user :: Crux.Structs.User.id_resolvable(), token :: String.t() | nil) ::
               {:ok, Webhook.t()} | {:error, term()}
       def get_webhook(user, token \\ nil) do
         request = Crux.Rest.Functions.get_webhook(user, token)
@@ -2289,7 +2334,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.get_webhook/2`, but raises an exception if it fails."
 
-      @spec get_webhook!(user :: Crux.Rest.Util.user_id_resolvable(), token :: String.t() | nil) ::
+      @spec get_webhook!(user :: Crux.Structs.User.id_resolvable(), token :: String.t() | nil) ::
               Webhook.t() | no_return()
       def get_webhook!(user, token \\ nil) do
         request = Crux.Rest.Functions.get_webhook(user, token)
@@ -2298,7 +2343,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.leave_guild/1`"
 
-      @spec leave_guild(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | {:error, term()}
+      @spec leave_guild(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | {:error, term()}
       def leave_guild(guild) do
         request = Crux.Rest.Functions.leave_guild(guild)
         request(request)
@@ -2306,7 +2351,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.leave_guild/1`, but raises an exception if it fails."
 
-      @spec leave_guild!(guild :: Crux.Rest.Util.guild_id_resolvable()) :: :ok | no_return()
+      @spec leave_guild!(guild :: Crux.Structs.Guild.id_resolvable()) :: :ok | no_return()
       def leave_guild!(guild) do
         request = Crux.Rest.Functions.leave_guild(guild)
         request!(request)
@@ -2314,8 +2359,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.list_channel_webhooks/1`"
 
-      @spec list_channel_webhooks(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Webhook.t()}} | {:error, term()}
+      @spec list_channel_webhooks(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()}}
+              | {:error, term()}
       def list_channel_webhooks(channel) do
         request = Crux.Rest.Functions.list_channel_webhooks(channel)
         request(request)
@@ -2323,8 +2369,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.list_channel_webhooks/1`, but raises an exception if it fails."
 
-      @spec list_channel_webhooks!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Webhook.t()} | no_return()
+      @spec list_channel_webhooks!(channel :: Crux.Structs.Channel.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
       def list_channel_webhooks!(channel) do
         request = Crux.Rest.Functions.list_channel_webhooks(channel)
         request!(request)
@@ -2332,8 +2378,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.list_guild_emojis/1`"
 
-      @spec list_guild_emojis(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Emoji.t()}} | {:error, term()}
+      @spec list_guild_emojis(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}}
+              | {:error, term()}
       def list_guild_emojis(guild) do
         request = Crux.Rest.Functions.list_guild_emojis(guild)
         request(request)
@@ -2341,8 +2388,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.list_guild_emojis/1`, but raises an exception if it fails."
 
-      @spec list_guild_emojis!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Emoji.t()} | no_return()
+      @spec list_guild_emojis!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}
+              | no_return()
       def list_guild_emojis!(guild) do
         request = Crux.Rest.Functions.list_guild_emojis(guild)
         request!(request)
@@ -2351,9 +2399,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.list_guild_members/2`"
 
       @spec list_guild_members(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.list_guild_members_options()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => Member.t()}} | {:error, term()}
+            ) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()}}
+              | {:error, term()}
       def list_guild_members(guild, options) do
         request = Crux.Rest.Functions.list_guild_members(guild, options)
         request(request)
@@ -2362,9 +2412,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.list_guild_members/2`, but raises an exception if it fails."
 
       @spec list_guild_members!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.list_guild_members_options()
-            ) :: %{required(Crux.Rest.snowflake()) => Member.t()} | no_return()
+            ) :: %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()} | no_return()
       def list_guild_members!(guild, options) do
         request = Crux.Rest.Functions.list_guild_members(guild, options)
         request!(request)
@@ -2372,8 +2422,9 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.list_guild_webhooks/1`"
 
-      @spec list_guild_webhooks(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              {:ok, %{required(Crux.Rest.snowflake()) => Webhook.t()}} | {:error, term()}
+      @spec list_guild_webhooks(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()}}
+              | {:error, term()}
       def list_guild_webhooks(guild) do
         request = Crux.Rest.Functions.list_guild_webhooks(guild)
         request(request)
@@ -2381,8 +2432,8 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.list_guild_webhooks/1`, but raises an exception if it fails."
 
-      @spec list_guild_webhooks!(guild :: Crux.Rest.Util.guild_id_resolvable()) ::
-              %{required(Crux.Rest.snowflake()) => Webhook.t()} | no_return()
+      @spec list_guild_webhooks!(guild :: Crux.Structs.Guild.id_resolvable()) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
       def list_guild_webhooks!(guild) do
         request = Crux.Rest.Functions.list_guild_webhooks(guild)
         request!(request)
@@ -2391,9 +2442,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_channel/2`"
 
       @spec modify_channel(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               data :: Crux.Rest.modify_channel_data()
-            ) :: {:ok, Channel.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Channel.t()} | {:error, term()}
       def modify_channel(channel, data) do
         request = Crux.Rest.Functions.modify_channel(channel, data)
         request(request)
@@ -2402,9 +2453,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_channel/2`, but raises an exception if it fails."
 
       @spec modify_channel!(
-              channel :: Crux.Rest.Util.channel_id_resolvable(),
+              channel :: Crux.Structs.Channel.id_resolvable(),
               data :: Crux.Rest.modify_channel_data()
-            ) :: Channel.t() | no_return()
+            ) :: Crux.Structs.Channel.t() | no_return()
       def modify_channel!(channel, data) do
         request = Crux.Rest.Functions.modify_channel(channel, data)
         request!(request)
@@ -2413,7 +2464,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_current_user/1`"
 
       @spec modify_current_user(data :: Crux.Rest.modify_current_user_data()) ::
-              {:ok, User.t()} | {:error, term()}
+              {:ok, Crux.Structs.User.t()} | {:error, term()}
       def modify_current_user(data) do
         request = Crux.Rest.Functions.modify_current_user(data)
         request(request)
@@ -2422,7 +2473,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_current_user/1`, but raises an exception if it fails."
 
       @spec modify_current_user!(data :: Crux.Rest.modify_current_user_data()) ::
-              User.t() | no_return()
+              Crux.Structs.User.t() | no_return()
       def modify_current_user!(data) do
         request = Crux.Rest.Functions.modify_current_user(data)
         request!(request)
@@ -2431,7 +2482,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_current_users_nick/3`"
 
       @spec modify_current_users_nick(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               nick :: String.t(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
@@ -2443,7 +2494,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_current_users_nick/3`, but raises an exception if it fails."
 
       @spec modify_current_users_nick!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               nick :: String.t(),
               reason :: String.t()
             ) :: :ok | no_return()
@@ -2455,9 +2506,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild/2`"
 
       @spec modify_guild(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.modify_guild_data()
-            ) :: {:ok, Guild.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Guild.t()} | {:error, term()}
       def modify_guild(guild, data) do
         request = Crux.Rest.Functions.modify_guild(guild, data)
         request(request)
@@ -2466,9 +2517,9 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild/2`, but raises an exception if it fails."
 
       @spec modify_guild!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.modify_guild_data()
-            ) :: Guild.t() | no_return()
+            ) :: Crux.Structs.Guild.t() | no_return()
       def modify_guild!(guild, data) do
         request = Crux.Rest.Functions.modify_guild(guild, data)
         request!(request)
@@ -2477,7 +2528,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_channel_positions/2`"
 
       @spec modify_guild_channel_positions(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
             ) :: :ok | {:error, term()}
       def modify_guild_channel_positions(guild, channels) do
@@ -2488,7 +2539,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_channel_positions/2`, but raises an exception if it fails."
 
       @spec modify_guild_channel_positions!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
             ) :: :ok | no_return()
       def modify_guild_channel_positions!(guild, channels) do
@@ -2499,10 +2550,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_embed/2`"
 
       @spec modify_guild_embed(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data ::
-                %{optional(:enabled) => boolean(), optional(:channel_id) => Crux.Rest.snowflake()}
-                | [{:enabled, boolean()} | {:channel_id, Crux.Rest.snowflake()}]
+                %{
+                  optional(:enabled) => boolean(),
+                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                }
+                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
             ) :: {:ok, term()} | {:error, term()}
       def modify_guild_embed(guild, data) do
         request = Crux.Rest.Functions.modify_guild_embed(guild, data)
@@ -2512,10 +2566,13 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_embed/2`, but raises an exception if it fails."
 
       @spec modify_guild_embed!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data ::
-                %{optional(:enabled) => boolean(), optional(:channel_id) => Crux.Rest.snowflake()}
-                | [{:enabled, boolean()} | {:channel_id, Crux.Rest.snowflake()}]
+                %{
+                  optional(:enabled) => boolean(),
+                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                }
+                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
             ) :: term() | no_return()
       def modify_guild_embed!(guild, data) do
         request = Crux.Rest.Functions.modify_guild_embed(guild, data)
@@ -2525,10 +2582,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_emoji/3`"
 
       @spec modify_guild_emoji(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable(),
               data :: Crux.Rest.modify_guild_emoji_data()
-            ) :: {:ok, Emoji} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Emoji} | {:error, term()}
       def modify_guild_emoji(guild, emoji, data) do
         request = Crux.Rest.Functions.modify_guild_emoji(guild, emoji, data)
         request(request)
@@ -2537,10 +2594,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_emoji/3`, but raises an exception if it fails."
 
       @spec modify_guild_emoji!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              emoji :: Crux.Rest.Util.emoji_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              emoji :: Crux.Structs.Emoji.id_resolvable(),
               data :: Crux.Rest.modify_guild_emoji_data()
-            ) :: Emoji | no_return()
+            ) :: Crux.Structs.Emoji | no_return()
       def modify_guild_emoji!(guild, emoji, data) do
         request = Crux.Rest.Functions.modify_guild_emoji(guild, emoji, data)
         request!(request)
@@ -2549,8 +2606,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_integration/3`"
 
       @spec modify_guild_integration(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable(),
               data ::
                 %{
                   optional(:expire_behavior) => integer(),
@@ -2571,8 +2628,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_integration/3`, but raises an exception if it fails."
 
       @spec modify_guild_integration!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable(),
               data ::
                 %{
                   optional(:expire_behavior) => integer(),
@@ -2593,34 +2650,34 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_member/3`"
 
       @spec modify_guild_member(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
               data :: Crux.Rest.modify_guild_member_data()
             ) :: :ok | {:error, term()}
-      def modify_guild_member(guild, member, data) do
-        request = Crux.Rest.Functions.modify_guild_member(guild, member, data)
+      def modify_guild_member(guild, user, data) do
+        request = Crux.Rest.Functions.modify_guild_member(guild, user, data)
         request(request)
       end
 
       @doc "The same as `c:Crux.Rest.modify_guild_member/3`, but raises an exception if it fails."
 
       @spec modify_guild_member!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
               data :: Crux.Rest.modify_guild_member_data()
             ) :: :ok | no_return()
-      def modify_guild_member!(guild, member, data) do
-        request = Crux.Rest.Functions.modify_guild_member(guild, member, data)
+      def modify_guild_member!(guild, user, data) do
+        request = Crux.Rest.Functions.modify_guild_member(guild, user, data)
         request!(request)
       end
 
       @doc "See `c:Crux.Rest.modify_guild_role/3`"
 
       @spec modify_guild_role(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
-            ) :: {:ok, Role.t()} | {:error, term()}
+            ) :: {:ok, Crux.Structs.Role.t()} | {:error, term()}
       def modify_guild_role(guild, role, data) do
         request = Crux.Rest.Functions.modify_guild_role(guild, role, data)
         request(request)
@@ -2629,10 +2686,10 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_role/3`, but raises an exception if it fails."
 
       @spec modify_guild_role!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               data :: Crux.Rest.guild_role_data()
-            ) :: Role.t() | no_return()
+            ) :: Crux.Structs.Role.t() | no_return()
       def modify_guild_role!(guild, role, data) do
         request = Crux.Rest.Functions.modify_guild_role(guild, role, data)
         request!(request)
@@ -2641,9 +2698,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.modify_guild_role_positions/2`"
 
       @spec modify_guild_role_positions(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.Util.modify_guild_role_positions_data()
-            ) :: {:ok, %{required(Crux.Rest.snowflake()) => Role.t()}} | {:error, term()}
+            ) ::
+              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}}
+              | {:error, term()}
       def modify_guild_role_positions(guild, data) do
         request = Crux.Rest.Functions.modify_guild_role_positions(guild, data)
         request(request)
@@ -2652,9 +2711,11 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.modify_guild_role_positions/2`, but raises an exception if it fails."
 
       @spec modify_guild_role_positions!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.Util.modify_guild_role_positions_data()
-            ) :: %{required(Crux.Rest.snowflake()) => Role.t()} | no_return()
+            ) ::
+              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
+              | no_return()
       def modify_guild_role_positions!(guild, data) do
         request = Crux.Rest.Functions.modify_guild_role_positions(guild, data)
         request!(request)
@@ -2663,8 +2724,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.remove_guild_ban/3`"
 
       @spec remove_guild_ban(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
       def remove_guild_ban(guild, user, reason \\ nil) do
@@ -2675,8 +2736,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.remove_guild_ban/3`, but raises an exception if it fails."
 
       @spec remove_guild_ban!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
       def remove_guild_ban!(guild, user, reason \\ nil) do
@@ -2687,34 +2748,34 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.remove_guild_member_role/4`"
 
       @spec remove_guild_member_role(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | {:error, term()}
-      def remove_guild_member_role(guild, member, role, reason \\ nil) do
-        request = Crux.Rest.Functions.remove_guild_member_role(guild, member, role, reason)
+      def remove_guild_member_role(guild, user, role, reason \\ nil) do
+        request = Crux.Rest.Functions.remove_guild_member_role(guild, user, role, reason)
         request(request)
       end
 
       @doc "The same as `c:Crux.Rest.remove_guild_member_role/4`, but raises an exception if it fails."
 
       @spec remove_guild_member_role!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              member :: Crux.Rest.Util.user_id_resolvable(),
-              role :: Crux.Rest.Util.role_id_resolvable(),
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              member :: Crux.Structs.User.id_resolvable(),
+              role :: Crux.Structs.Role.id_resolvable(),
               reason :: String.t()
             ) :: :ok | no_return()
-      def remove_guild_member_role!(guild, member, role, reason \\ nil) do
-        request = Crux.Rest.Functions.remove_guild_member_role(guild, member, role, reason)
+      def remove_guild_member_role!(guild, user, role, reason \\ nil) do
+        request = Crux.Rest.Functions.remove_guild_member_role(guild, user, role, reason)
         request!(request)
       end
 
       @doc "See `c:Crux.Rest.sync_guild_integration/2`"
 
       @spec sync_guild_integration(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable()
             ) :: :ok | {:error, term()}
       def sync_guild_integration(guild, integration) do
         request = Crux.Rest.Functions.sync_guild_integration(guild, integration)
@@ -2724,8 +2785,8 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.sync_guild_integration/2`, but raises an exception if it fails."
 
       @spec sync_guild_integration!(
-              guild :: Crux.Rest.Util.guild_id_resolvable(),
-              integration_id :: Crux.Rest.snowflake()
+              guild :: Crux.Structs.Guild.id_resolvable(),
+              integration_id :: Crux.Structs.Snowflake.resolvable()
             ) :: :ok | no_return()
       def sync_guild_integration!(guild, integration) do
         request = Crux.Rest.Functions.sync_guild_integration(guild, integration)
@@ -2734,7 +2795,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "See `c:Crux.Rest.trigger_typing/1`"
 
-      @spec trigger_typing(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
+      @spec trigger_typing(channel :: Crux.Structs.Channel.id_resolvable()) ::
               :ok | {:error, term()}
       def trigger_typing(channel) do
         request = Crux.Rest.Functions.trigger_typing(channel)
@@ -2743,8 +2804,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @doc "The same as `c:Crux.Rest.trigger_typing/1`, but raises an exception if it fails."
 
-      @spec trigger_typing!(channel :: Crux.Rest.Util.channel_id_resolvable()) ::
-              :ok | no_return()
+      @spec trigger_typing!(channel :: Crux.Structs.Channel.id_resolvable()) :: :ok | no_return()
       def trigger_typing!(channel) do
         request = Crux.Rest.Functions.trigger_typing(channel)
         request!(request)
@@ -2753,18 +2813,18 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.update_webhook/3`"
 
       @spec update_webhook(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t() | nil,
               data ::
                 %{
                   optional(:name) => String.t(),
                   optional(:avatar) => Crux.Rest.Util.image(),
-                  optional(:channel_id) => Crux.Rest.snowflake()
+                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
                 }
                 | [
                     {:name, String.t()}
                     | {:avatar, Crux.Rest.Util.image()}
-                    | {:channel_id, Crux.Rest.snowflake()}
+                    | {:channel_id, Crux.Structs.Snowflake.resolvable()}
                   ]
             ) :: {:ok, Webhook.t()} | {:error, term()}
       def update_webhook(user, token \\ nil, data) do
@@ -2775,18 +2835,18 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.update_webhook/3`, but raises an exception if it fails."
 
       @spec update_webhook!(
-              user :: Crux.Rest.Util.user_id_resolvable(),
+              user :: Crux.Structs.User.id_resolvable(),
               token :: String.t() | nil,
               data ::
                 %{
                   optional(:name) => String.t(),
                   optional(:avatar) => Crux.Rest.Util.image(),
-                  optional(:channel_id) => Crux.Rest.snowflake()
+                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
                 }
                 | [
                     {:name, String.t()}
                     | {:avatar, Crux.Rest.Util.image()}
-                    | {:channel_id, Crux.Rest.snowflake()}
+                    | {:channel_id, Crux.Structs.Snowflake.resolvable()}
                   ]
             ) :: Webhook.t() | no_return()
       def update_webhook!(user, token \\ nil, data) do

--- a/lib/rest/gen/bang.ex
+++ b/lib/rest/gen/bang.ex
@@ -399,8 +399,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback get_current_user_guilds!(data :: Crux.Rest.get_current_user_guild_data()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Guild.t()} | no_return()
 
       @doc "The same as `c:get_guild/1`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -426,7 +425,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @callback get_guild_bans!(guild :: Crux.Structs.Guild.id_resolvable()) ::
                   %{
-                    required(Crux.Structs.Snowflake.resolvable()) => %{
+                    required(Crux.Structs.Snowflake.t()) => %{
                       required(:user) => Crux.Structs.User.t(),
                       required(:reason) => String.t() | nil
                     }
@@ -437,7 +436,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback get_guild_channels!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Channel.t()}
                   | no_return()
 
       @doc "The same as `c:get_guild_embed/1`, but raises an exception if it fails."
@@ -486,8 +485,7 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback get_guild_roles!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()} | no_return()
 
       @doc "The same as `c:get_guild_vanity_url/1`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -520,14 +518,14 @@ defmodule Crux.Rest.Gen.Bang do
                   channel :: Crux.Structs.Channel.id_resolvable(),
                   args :: Crux.Rest.get_messages_data()
                 ) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()}
                   | no_return()
 
       @doc "The same as `c:get_pinned_messages/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback get_pinned_messages!(channel :: Crux.Structs.Channel.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()}
                   | no_return()
 
       @doc "The same as `c:get_reactions/3`, but raises an exception if it fails."
@@ -538,8 +536,7 @@ defmodule Crux.Rest.Gen.Bang do
                   emoji :: Crux.Structs.Emoji.identifier_resolvable(),
                   args :: Crux.Rest.get_reactions_data()
                 ) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.User.t()} | no_return()
 
       @doc "The same as `c:get_reactions/4`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -550,8 +547,7 @@ defmodule Crux.Rest.Gen.Bang do
                   emoji :: Crux.Structs.Emoji.identifier_resolvable(),
                   args :: Crux.Rest.get_reactions_data()
                 ) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.User.t()} | no_return()
 
       @doc "The same as `c:get_user/1`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -573,14 +569,13 @@ defmodule Crux.Rest.Gen.Bang do
       Version.since("0.2.0")
 
       @callback list_channel_webhooks!(channel :: Crux.Structs.Channel.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Webhook.t()} | no_return()
 
       @doc "The same as `c:list_guild_emojis/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback list_guild_emojis!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Emoji.t()} | no_return()
 
       @doc "The same as `c:list_guild_members/2`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -588,13 +583,13 @@ defmodule Crux.Rest.Gen.Bang do
       @callback list_guild_members!(
                   guild :: Crux.Structs.Guild.id_resolvable(),
                   options :: Crux.Rest.list_guild_members_options()
-                ) :: %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()} | no_return()
+                ) :: %{required(Crux.Structs.Snowflake.t()) => Member.t()} | no_return()
 
       @doc "The same as `c:list_guild_webhooks/1`, but raises an exception if it fails."
       Version.since("0.2.0")
 
       @callback list_guild_webhooks!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Webhook.t()} | no_return()
 
       @doc "The same as `c:modify_channel/2`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -632,7 +627,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @callback modify_guild_channel_positions!(
                   guild :: Crux.Structs.Guild.id_resolvable(),
-                  channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
+                  channels :: [Crux.Structs.Channel.position_resolvable()]
                 ) :: :ok | no_return()
 
       @doc "The same as `c:modify_guild_embed/2`, but raises an exception if it fails."
@@ -643,9 +638,12 @@ defmodule Crux.Rest.Gen.Bang do
                   data ::
                     %{
                       optional(:enabled) => boolean(),
-                      optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                      optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                     }
-                    | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
+                    | [
+                        {:enabled, boolean()}
+                        | {:channel_id, Crux.Structs.Channel.id_resolvable()}
+                      ]
                 ) :: term() | no_return()
 
       @doc "The same as `c:modify_guild_emoji/3`, but raises an exception if it fails."
@@ -701,8 +699,7 @@ defmodule Crux.Rest.Gen.Bang do
                   guild :: Crux.Structs.Guild.id_resolvable(),
                   data :: Crux.Rest.Util.modify_guild_role_positions_data()
                 ) ::
-                  %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
-                  | no_return()
+                  %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()} | no_return()
 
       @doc "The same as `c:remove_guild_ban/3`, but raises an exception if it fails."
       Version.since("0.2.0")
@@ -747,12 +744,12 @@ defmodule Crux.Rest.Gen.Bang do
                     %{
                       optional(:name) => String.t(),
                       optional(:avatar) => Crux.Rest.Util.image(),
-                      optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                      optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                     }
                     | [
                         {:name, String.t()}
                         | {:avatar, Crux.Rest.Util.image()}
-                        | {:channel_id, Crux.Structs.Snowflake.resolvable()}
+                        | {:channel_id, Crux.Structs.Channel.id_resolvable()}
                       ]
                 ) :: Webhook.t() | no_return()
 
@@ -1879,7 +1876,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_current_user_guilds/1`"
 
       @spec get_current_user_guilds(data :: Crux.Rest.get_current_user_guild_data()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Guild.t()}}
               | {:error, term()}
       def get_current_user_guilds(data) do
         request = Crux.Rest.Functions.get_current_user_guilds(data)
@@ -1889,8 +1886,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_current_user_guilds/1`, but raises an exception if it fails."
 
       @spec get_current_user_guilds!(data :: Crux.Rest.get_current_user_guild_data()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Guild.t()}
-              | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Guild.t()} | no_return()
       def get_current_user_guilds!(data) do
         request = Crux.Rest.Functions.get_current_user_guilds(data)
         request!(request)
@@ -1946,7 +1942,7 @@ defmodule Crux.Rest.Gen.Bang do
       @spec get_guild_bans(guild :: Crux.Structs.Guild.id_resolvable()) ::
               {:ok,
                %{
-                 required(Crux.Structs.Snowflake.resolvable()) => %{
+                 required(Crux.Structs.Snowflake.t()) => %{
                    required(:user) => Crux.Structs.User.t(),
                    required(:reason) => String.t() | nil
                  }
@@ -1961,7 +1957,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @spec get_guild_bans!(guild :: Crux.Structs.Guild.id_resolvable()) ::
               %{
-                required(Crux.Structs.Snowflake.resolvable()) => %{
+                required(Crux.Structs.Snowflake.t()) => %{
                   required(:user) => Crux.Structs.User.t(),
                   required(:reason) => String.t() | nil
                 }
@@ -1975,7 +1971,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_channels/1`"
 
       @spec get_guild_channels(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Channel.t()}}
               | {:error, term()}
       def get_guild_channels(guild) do
         request = Crux.Rest.Functions.get_guild_channels(guild)
@@ -1985,8 +1981,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_channels/1`, but raises an exception if it fails."
 
       @spec get_guild_channels!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Channel.t()}
-              | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Channel.t()} | no_return()
       def get_guild_channels!(guild) do
         request = Crux.Rest.Functions.get_guild_channels(guild)
         request!(request)
@@ -2114,7 +2109,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_guild_roles/1`"
 
       @spec get_guild_roles(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()}}
               | {:error, term()}
       def get_guild_roles(guild) do
         request = Crux.Rest.Functions.get_guild_roles(guild)
@@ -2124,8 +2119,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_guild_roles/1`, but raises an exception if it fails."
 
       @spec get_guild_roles!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
-              | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()} | no_return()
       def get_guild_roles!(guild) do
         request = Crux.Rest.Functions.get_guild_roles(guild)
         request!(request)
@@ -2211,7 +2205,7 @@ defmodule Crux.Rest.Gen.Bang do
               channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.get_messages_data()
             ) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()}}
               | {:error, term()}
       def get_messages(channel, data) do
         request = Crux.Rest.Functions.get_messages(channel, data)
@@ -2223,9 +2217,7 @@ defmodule Crux.Rest.Gen.Bang do
       @spec get_messages!(
               channel :: Crux.Structs.Channel.id_resolvable(),
               args :: Crux.Rest.get_messages_data()
-            ) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
-              | no_return()
+            ) :: %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()} | no_return()
       def get_messages!(channel, data) do
         request = Crux.Rest.Functions.get_messages(channel, data)
         request!(request)
@@ -2234,7 +2226,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.get_pinned_messages/1`"
 
       @spec get_pinned_messages(channel :: Crux.Structs.Channel.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()}}
               | {:error, term()}
       def get_pinned_messages(channel) do
         request = Crux.Rest.Functions.get_pinned_messages(channel)
@@ -2244,8 +2236,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.get_pinned_messages/1`, but raises an exception if it fails."
 
       @spec get_pinned_messages!(channel :: Crux.Structs.Channel.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Message.t()}
-              | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Message.t()} | no_return()
       def get_pinned_messages!(channel) do
         request = Crux.Rest.Functions.get_pinned_messages(channel)
         request!(request)
@@ -2259,7 +2250,7 @@ defmodule Crux.Rest.Gen.Bang do
               emoji :: Crux.Structs.Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
             ) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.User.t()}}
               | {:error, term()}
       def get_reactions(
             channel_or_message,
@@ -2285,9 +2276,7 @@ defmodule Crux.Rest.Gen.Bang do
               message :: Crux.Structs.Message.id_resolvable(),
               emoji :: Crux.Structs.Emoji.identifier_resolvable(),
               args :: Crux.Rest.get_reactions_data()
-            ) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.User.t()}
-              | no_return()
+            ) :: %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.User.t()} | no_return()
       def get_reactions!(
             channel_or_message,
             emoji_or_message_id,
@@ -2360,8 +2349,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.list_channel_webhooks/1`"
 
       @spec list_channel_webhooks(channel :: Crux.Structs.Channel.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()}}
-              | {:error, term()}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Webhook.t()}} | {:error, term()}
       def list_channel_webhooks(channel) do
         request = Crux.Rest.Functions.list_channel_webhooks(channel)
         request(request)
@@ -2370,7 +2358,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.list_channel_webhooks/1`, but raises an exception if it fails."
 
       @spec list_channel_webhooks!(channel :: Crux.Structs.Channel.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Webhook.t()} | no_return()
       def list_channel_webhooks!(channel) do
         request = Crux.Rest.Functions.list_channel_webhooks(channel)
         request!(request)
@@ -2379,7 +2367,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.list_guild_emojis/1`"
 
       @spec list_guild_emojis(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Emoji.t()}}
               | {:error, term()}
       def list_guild_emojis(guild) do
         request = Crux.Rest.Functions.list_guild_emojis(guild)
@@ -2389,8 +2377,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.list_guild_emojis/1`, but raises an exception if it fails."
 
       @spec list_guild_emojis!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Emoji.t()}
-              | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Emoji.t()} | no_return()
       def list_guild_emojis!(guild) do
         request = Crux.Rest.Functions.list_guild_emojis(guild)
         request!(request)
@@ -2401,9 +2388,7 @@ defmodule Crux.Rest.Gen.Bang do
       @spec list_guild_members(
               guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.list_guild_members_options()
-            ) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()}}
-              | {:error, term()}
+            ) :: {:ok, %{required(Crux.Structs.Snowflake.t()) => Member.t()}} | {:error, term()}
       def list_guild_members(guild, options) do
         request = Crux.Rest.Functions.list_guild_members(guild, options)
         request(request)
@@ -2414,7 +2399,7 @@ defmodule Crux.Rest.Gen.Bang do
       @spec list_guild_members!(
               guild :: Crux.Structs.Guild.id_resolvable(),
               options :: Crux.Rest.list_guild_members_options()
-            ) :: %{required(Crux.Structs.Snowflake.resolvable()) => Member.t()} | no_return()
+            ) :: %{required(Crux.Structs.Snowflake.t()) => Member.t()} | no_return()
       def list_guild_members!(guild, options) do
         request = Crux.Rest.Functions.list_guild_members(guild, options)
         request!(request)
@@ -2423,8 +2408,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "See `c:Crux.Rest.list_guild_webhooks/1`"
 
       @spec list_guild_webhooks(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()}}
-              | {:error, term()}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Webhook.t()}} | {:error, term()}
       def list_guild_webhooks(guild) do
         request = Crux.Rest.Functions.list_guild_webhooks(guild)
         request(request)
@@ -2433,7 +2417,7 @@ defmodule Crux.Rest.Gen.Bang do
       @doc "The same as `c:Crux.Rest.list_guild_webhooks/1`, but raises an exception if it fails."
 
       @spec list_guild_webhooks!(guild :: Crux.Structs.Guild.id_resolvable()) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Webhook.t()} | no_return()
+              %{required(Crux.Structs.Snowflake.t()) => Webhook.t()} | no_return()
       def list_guild_webhooks!(guild) do
         request = Crux.Rest.Functions.list_guild_webhooks(guild)
         request!(request)
@@ -2529,7 +2513,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @spec modify_guild_channel_positions(
               guild :: Crux.Structs.Guild.id_resolvable(),
-              channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
+              channels :: [Crux.Structs.Channel.position_resolvable()]
             ) :: :ok | {:error, term()}
       def modify_guild_channel_positions(guild, channels) do
         request = Crux.Rest.Functions.modify_guild_channel_positions(guild, channels)
@@ -2540,7 +2524,7 @@ defmodule Crux.Rest.Gen.Bang do
 
       @spec modify_guild_channel_positions!(
               guild :: Crux.Structs.Guild.id_resolvable(),
-              channels :: [Crux.Rest.modify_guild_channel_positions_data_entry()]
+              channels :: [Crux.Structs.Channel.position_resolvable()]
             ) :: :ok | no_return()
       def modify_guild_channel_positions!(guild, channels) do
         request = Crux.Rest.Functions.modify_guild_channel_positions(guild, channels)
@@ -2554,9 +2538,9 @@ defmodule Crux.Rest.Gen.Bang do
               data ::
                 %{
                   optional(:enabled) => boolean(),
-                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                  optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                 }
-                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
+                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Channel.id_resolvable()}]
             ) :: {:ok, term()} | {:error, term()}
       def modify_guild_embed(guild, data) do
         request = Crux.Rest.Functions.modify_guild_embed(guild, data)
@@ -2570,9 +2554,9 @@ defmodule Crux.Rest.Gen.Bang do
               data ::
                 %{
                   optional(:enabled) => boolean(),
-                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                  optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                 }
-                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Snowflake.resolvable()}]
+                | [{:enabled, boolean()} | {:channel_id, Crux.Structs.Channel.id_resolvable()}]
             ) :: term() | no_return()
       def modify_guild_embed!(guild, data) do
         request = Crux.Rest.Functions.modify_guild_embed(guild, data)
@@ -2701,7 +2685,7 @@ defmodule Crux.Rest.Gen.Bang do
               guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.Util.modify_guild_role_positions_data()
             ) ::
-              {:ok, %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}}
+              {:ok, %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()}}
               | {:error, term()}
       def modify_guild_role_positions(guild, data) do
         request = Crux.Rest.Functions.modify_guild_role_positions(guild, data)
@@ -2713,9 +2697,7 @@ defmodule Crux.Rest.Gen.Bang do
       @spec modify_guild_role_positions!(
               guild :: Crux.Structs.Guild.id_resolvable(),
               data :: Crux.Rest.Util.modify_guild_role_positions_data()
-            ) ::
-              %{required(Crux.Structs.Snowflake.resolvable()) => Crux.Structs.Role.t()}
-              | no_return()
+            ) :: %{required(Crux.Structs.Snowflake.t()) => Crux.Structs.Role.t()} | no_return()
       def modify_guild_role_positions!(guild, data) do
         request = Crux.Rest.Functions.modify_guild_role_positions(guild, data)
         request!(request)
@@ -2819,12 +2801,12 @@ defmodule Crux.Rest.Gen.Bang do
                 %{
                   optional(:name) => String.t(),
                   optional(:avatar) => Crux.Rest.Util.image(),
-                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                  optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                 }
                 | [
                     {:name, String.t()}
                     | {:avatar, Crux.Rest.Util.image()}
-                    | {:channel_id, Crux.Structs.Snowflake.resolvable()}
+                    | {:channel_id, Crux.Structs.Channel.id_resolvable()}
                   ]
             ) :: {:ok, Webhook.t()} | {:error, term()}
       def update_webhook(user, token \\ nil, data) do
@@ -2841,12 +2823,12 @@ defmodule Crux.Rest.Gen.Bang do
                 %{
                   optional(:name) => String.t(),
                   optional(:avatar) => Crux.Rest.Util.image(),
-                  optional(:channel_id) => Crux.Structs.Snowflake.resolvable()
+                  optional(:channel_id) => Crux.Structs.Channel.id_resolvable()
                 }
                 | [
                     {:name, String.t()}
                     | {:avatar, Crux.Rest.Util.image()}
-                    | {:channel_id, Crux.Structs.Snowflake.resolvable()}
+                    | {:channel_id, Crux.Structs.Channel.id_resolvable()}
                   ]
             ) :: Webhook.t() | no_return()
       def update_webhook!(user, token \\ nil, data) do

--- a/lib/rest/request.ex
+++ b/lib/rest/request.ex
@@ -9,6 +9,8 @@ defmodule Crux.Rest.Request do
 
   Version.modulesince("0.2.0")
 
+  @methods ~w(get put patch post delete)a
+
   @enforce_keys [:method, :path]
   defstruct [
     :method,
@@ -40,14 +42,17 @@ defmodule Crux.Rest.Request do
           params: list() | nil
         }
 
+  @type method :: :get | :put | :patch | :post | :delete
+
   ### Create / Set
 
   @doc false
   Version.since("0.2.0")
-  @spec new(method :: atom(), path :: String.t(), data :: term()) :: t()
+  @spec new(method :: method(), path :: String.t(), data :: term()) :: t()
   def new(method, path, data \\ "")
 
-  def new(method, path, data) do
+  def new(method, path, data)
+      when method in @methods do
     %__MODULE__{
       method: method,
       route: get_route(path),

--- a/lib/rest/util.ex
+++ b/lib/rest/util.ex
@@ -117,10 +117,25 @@ defmodule Crux.Rest.Util do
 
   ### End Attachment / Image
 
+  @doc """
+    Updates a value in `map` with the given `fun`.
+    Is a noop if `key` is not in `map`.
+  """
+  Version.since("0.2.1")
+  @spec optional_update_in_map(map(), atom(), (term -> term)) :: map()
+  def optional_update_in_map(map, key, fun) do
+    case map do
+      %{^key => val} -> Map.put(map, key, fun.(val))
+      _ -> map
+    end
+  end
+
   ### Resolvables
 
   @typedoc """
     All available types that can be resolved into a role id.
+
+  > Deprecated: Use `Crux.Structs.Role.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type role_id_resolvable :: Role.t() | Crux.Rest.snowflake()
@@ -142,6 +157,7 @@ defmodule Crux.Rest.Util do
   376146940762783746
 
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.Role)` instead"
   @spec resolve_role_id(role :: role_id_resolvable()) :: integer()
   Version.since("0.1.0")
   def resolve_role_id(%Role{id: role_id}), do: role_id
@@ -149,12 +165,16 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into an emoji identifier.
+
+  > Deprecated: Use `Crux.Structs.Emoji.identifier_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type emoji_identifier_resolvable :: Reaction.t() | Emoji.t() | String.t()
 
   @typedoc """
     All available types that can be resolved into an emoji id.
+
+  > Deprecated: Use `Crux.Structs.Emoji.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type emoji_id_resolvable :: Reaction.t() | Emoji.t() | String.t()
@@ -179,6 +199,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.Emoji)` instead"
   @spec resolve_emoji_id(emoji :: emoji_id_resolvable()) :: String.t()
   Version.since("0.1.1")
   def resolve_emoji_id(%Emoji{id: id}) when not is_nil(id), do: id
@@ -187,6 +208,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a user id.
+
+  > Deprecated: Use `Crux.Structs.User.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type user_id_resolvable :: Member.t() | User.t() | integer()
@@ -211,6 +234,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.User)` instead"
   @spec resolve_user_id(user :: user_id_resolvable()) :: Crux.Rest.snowflake()
   Version.since("0.1.0")
   def resolve_user_id(%User{id: id}), do: id
@@ -219,6 +243,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a guild id.
+
+  > Deprecated: Use `Crux.Structs.Guild.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type guild_id_resolvable :: Guild.t() | Channel.t() | Message.t() | Crux.Rest.snowflake()
@@ -247,6 +273,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.Guild)` instead"
   @spec resolve_guild_id(guild :: guild_id_resolvable()) :: Crux.Rest.snowflake()
   Version.since("0.1.1")
   def resolve_guild_id(%Guild{id: id}), do: id
@@ -256,6 +283,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a channel id.
+
+  > Deprecated: Use `Crux.Structs.CHannel.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type channel_id_resolvable :: Message.t() | Channel.t() | Crux.Rest.snowflake()
@@ -280,6 +309,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.Channel)` instead"
   @spec resolve_channel_id(channel :: channel_id_resolvable()) :: Crux.Rest.snowflake()
   Version.since("0.1.1")
   def resolve_channel_id(%Channel{id: id}), do: id
@@ -288,6 +318,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a target for a permission overwrite.
+
+  > Deprecated: Use `Crux.Structs.Overwrite.target_resolvable()` instead
   """
   Version.typesince("0.1.1")
 
@@ -322,6 +354,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.Overwrite.resolve_target/1` instead"
   @spec resolve_overwrite_target(overwrite :: overwrite_target_resolvable()) ::
           {String.t() | :unknown, Crux.Rest.snowflake()}
   Version.since("0.1.1")
@@ -333,6 +366,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a message id.
+
+  > Deprecated: Use `Crux.Structs.Message.id_resolvable()` instead
   """
   Version.typesince("0.1.1")
   @type message_id_resolvable :: Message.t() | Crux.Rest.snowflake()
@@ -353,6 +388,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.resolve_id(&1, Crux.Structs.Message)` instead"
   @spec resolve_message_id(message :: message_id_resolvable()) :: Crux.Rest.snowflake()
   Version.since("0.1.0")
   def resolve_message_id(%Message{id: id}), do: id
@@ -360,6 +396,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types that can be resolved into a channel position.
+
+  > Deprecated: Use `Crux.Structs.Channel.position_resolvable()` instead
   """
   Version.typesince("0.1.1")
 
@@ -393,8 +431,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
-  Version.typesince("0.1.1")
-
+  @deprecated "Use `Crux.Structs.Channel.resolve_position/1` instead"
   @spec resolve_channel_position(channel :: channel_position_resolvable()) :: %{
           id: Crux.Rest.snowflake(),
           position: integer()
@@ -410,6 +447,8 @@ defmodule Crux.Rest.Util do
 
   @typedoc """
     All available types which can be resolved into a role position.
+
+  > Deprecated: Use `Crux.Structs.Role.position_resolvable()` instead.
   """
   Version.typesince("0.1.2")
 
@@ -442,6 +481,7 @@ defmodule Crux.Rest.Util do
 
     ```
   """
+  @deprecated "Use `Crux.Structs.Role.resolve_position/1` instead"
   @spec resolve_guild_role_position(role :: guild_role_position_resolvable()) :: %{
           id: Crux.Rest.snowflake(),
           position: integer()

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,9 @@ defmodule Crux.Rest.MixProject do
 
   defp deps do
     [
-      {:crux_structs, "~> 0.2"},
+      # {:crux_structs, "~> 0.2"},
+      {:crux_structs,
+       git: "https://github.com/spaceeec/crux_structs", branch: "feat/resolvables"},
       {:httpoison, "~> 1.5"},
       {:jason, "~> 1.1"},
       {:ex_doc,

--- a/mix.exs
+++ b/mix.exs
@@ -39,9 +39,7 @@ defmodule Crux.Rest.MixProject do
 
   defp deps do
     [
-      # {:crux_structs, "~> 0.2"},
-      {:crux_structs,
-       git: "https://github.com/spaceeec/crux_structs", branch: "feat/resolvables"},
+      {:crux_structs, "~> 0.2"},
       {:httpoison, "~> 1.5"},
       {:jason, "~> 1.1"},
       {:ex_doc,

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "credo": {:hex, :credo, "1.1.3", "bf31887b8914a4b7e1810ae2b5aab7c657698abbf4cca6a2335a094d57995168", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "crux_structs": {:git, "https://github.com/spaceeec/crux_structs", "264c5a841e923d6405862788155ac3f32dd8e531", [branch: "feat/resolvables"]},
-  "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.1.4", "c2f3b73c895d81d859cec7fcee7ffdb972c595fd8e85ab6f8c2adbf01cf7c29c", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "crux_structs": {:hex, :crux_structs, "0.2.1", "17c625b94b9807fceccd94219d4b7495529f65528aef64bea54f68dbb9398264", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.0", "397e750b879df18198afc66505ca87ecf6a96645545585899f6185178433cc09", [:mix], [], "hexpm"},
   "ex_doc": {:git, "https://github.com/spaceeec/ex_doc", "6ce4097da6c185c262b0b66c54496f0d0fad23b0", [branch: "feat/umbrella"]},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.5.1", "0f55b5b673b03c5c327dac7015a67cb571b99b631acc0bc1b0b98dcd6b9f2104", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "credo": {:hex, :credo, "1.1.3", "bf31887b8914a4b7e1810ae2b5aab7c657698abbf4cca6a2335a094d57995168", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "crux_structs": {:hex, :crux_structs, "0.2.0", "9fb5760b8ed0b00f6ff09d4de655bd4bd333dccbaaace36d45717d694df00914", [:mix], [], "hexpm"},
+  "crux_structs": {:git, "https://github.com/spaceeec/crux_structs", "264c5a841e923d6405862788155ac3f32dd8e531", [branch: "feat/resolvables"]},
   "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
   "ex_doc": {:git, "https://github.com/spaceeec/ex_doc", "6ce4097da6c185c262b0b66c54496f0d0fad23b0", [branch: "feat/umbrella"]},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This PR makes use of the `id_resolvable` types of the respective structs, as well as `Crux.Structs.resolve_id/2`.
Doing that moves the id resolving responsibilities to the `crux_structs` module, where it should (have) be(en in the first place).
> All functions resolving ids in `Crux.Rest.Util` are being deprecated and remove with the next major.


New feature is that `String.t` "snowflakes" can now be used without converting them to an integer first.
Example: `Rest.create_message("559412396586696706", content: "hello there")`


~~Depends (and waits) on https://github.com/SpaceEEC/crux_structs/pull/13 getting into a release.~~
Landed in `0.2.1`