### PR TITLE
Implement Get Original Interaction Response

### DIFF
--- a/lib/rest.ex
+++ b/lib/rest.ex
@@ -368,6 +368,20 @@ defmodule Crux.Rest do
                 interaction_token :: String.t(),
                 opts :: interaction_response()
               ) :: api_result(map())
+    
+
+    @doc """
+    Get the initially sent response to an interaction.
+
+    For more information see the [Discord Developer Documentation](https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response).
+    """
+    @doc since: "0.3.0"
+    @doc section: :slash_commands
+    @callback get_original_interaction_response(
+                application :: Application.id_resolvable(),
+                interaction_token :: String.t(),
+                opts :: modify_webhook_message_options()
+              ) :: api_result(Message.t())
 
     @doc """
     Modify the initially sent response to an interaction.

--- a/lib/rest/endpoints.ex
+++ b/lib/rest/endpoints.ex
@@ -118,5 +118,8 @@ defmodule Crux.Rest.Endpoints do
     route("/guilds/:guild_id/commands/:command_id")
   end
 
-  route("/interactions/:interaction_id/:interaction_token/callback")
+  route("/interactions/:interaction_id/:interaction_token") do
+    route("/callback")
+    route("/@original")
+  end
 end

--- a/lib/rest/endpoints.ex
+++ b/lib/rest/endpoints.ex
@@ -118,8 +118,5 @@ defmodule Crux.Rest.Endpoints do
     route("/guilds/:guild_id/commands/:command_id")
   end
 
-  route("/interactions/:interaction_id/:interaction_token") do
-    route("/callback")
-    route("/@original")
-  end
+  route("/interactions/:interaction_id/:interaction_token/callback")
 end

--- a/lib/rest/impl.ex
+++ b/lib/rest/impl.ex
@@ -203,6 +203,18 @@ defmodule Crux.Rest.Impl do
   end
 
   @doc section: :slash_commands
+  def get_original_interaction_response(interaction_id, interaction_token) do
+    interaction_id = Snowflake.to_snowflake(interaction_id)
+
+    path = Endpoints.webhooks_messages_original(application_id, interaction_token)
+
+    :get
+    |> Request.new(path, data)
+    |> Request.put_auth(false)
+    |> Request.put_transform(Message)
+  end
+
+  @doc section: :slash_commands
   def modify_original_interaction_response(application, interaction_token, opts) do
     application_id = Snowflake.to_snowflake(application)
 

--- a/lib/rest/impl.ex
+++ b/lib/rest/impl.ex
@@ -203,13 +203,13 @@ defmodule Crux.Rest.Impl do
   end
 
   @doc section: :slash_commands
-  def get_original_interaction_response(interaction_id, interaction_token) do
-    interaction_id = Snowflake.to_snowflake(interaction_id)
+  def get_original_interaction_response(application, interaction_token) do
+    application_id = Snowflake.to_snowflake(application)
 
     path = Endpoints.webhooks_messages_original(application_id, interaction_token)
 
     :get
-    |> Request.new(path, data)
+    |> Request.new(path)
     |> Request.put_auth(false)
     |> Request.put_transform(Message)
   end


### PR DESCRIPTION
Implements [Get Original Interaction Response](https://discord.com/developers/docs/interactions/slash-commands#get-original-interaction-response)

I needed to immediately add reactions to an interaction response but `create_interaction_response` only returns `:ok`.

Calling this method allows me to grab the `message_id` so I can immediately add my reactions.